### PR TITLE
Improving Memory Allocations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 // ┌─────────────────────┴─────────────────────────────────────────────────────────┐
 // │                         Core Rust Library                                     │
 // │  ┌─────────────────────────────────────────────────────────────────────────┐  │
-// │  │                           EipClient                                     │  │  
+// │  │                           EipClient                                     │  │
 // │  │  • Connection Management & Session Handling                            │  │
 // │  │  • Advanced Tag Operations & Program-Scoped Tag Support                │  │
 // │  │  • Complete Data Type Support (13 Allen-Bradley types)                 │  │
@@ -193,44 +193,44 @@
 //
 // =========================================================================
 
-use tokio::net::TcpStream;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::time::{timeout, Duration, Instant};
-use std::collections::HashMap;
-use tokio::runtime::Runtime;
-use tokio::sync::Mutex;
-use lazy_static::lazy_static;
 use crate::udt::UdtManager;
-use std::sync::Arc;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Duration, Instant};
 
-pub mod version;
+pub mod error;
+pub mod ffi;
 pub mod plc_manager;
+pub mod python;
+pub mod subscription;
 pub mod tag_manager;
 pub mod tag_path;
 pub mod udt;
-pub mod error;
-pub mod ffi;
-pub mod subscription;
-pub mod python;  // Add Python module
+pub mod version; // Add Python module
 
 // Re-export commonly used items
-pub use plc_manager::{PlcManager, PlcConfig, PlcConnection};
-pub use tag_manager::{TagManager, TagCache, TagMetadata, TagScope, TagPermissions};
+pub use error::{EtherNetIpError, Result};
+pub use plc_manager::{PlcConfig, PlcConnection, PlcManager};
+pub use subscription::{SubscriptionManager, SubscriptionOptions, TagSubscription};
+pub use tag_manager::{TagCache, TagManager, TagMetadata, TagPermissions, TagScope};
 pub use tag_path::TagPath;
 pub use udt::{UdtDefinition, UdtMember};
-pub use error::{EtherNetIpError, Result};
-pub use subscription::{TagSubscription, SubscriptionOptions, SubscriptionManager};
 
 // Static runtime and client management for FFI
 lazy_static! {
     /// Global Tokio runtime for handling async operations in FFI context
     static ref RUNTIME: Runtime = Runtime::new().unwrap();
-    
+
     /// Global storage for EipClient instances, indexed by client ID
     static ref CLIENTS: Mutex<HashMap<i32, EipClient>> = Mutex::new(HashMap::new());
-    
+
     /// Counter for generating unique client IDs
     static ref NEXT_ID: Mutex<i32> = Mutex::new(1);
 }
@@ -240,71 +240,71 @@ lazy_static! {
 // =========================================================================
 
 /// Represents a single operation in a batch request
-/// 
+///
 /// This enum defines the different types of operations that can be
 /// performed in a batch. Each operation specifies whether it's a read
 /// or write operation and includes the necessary parameters.
 #[derive(Debug, Clone)]
 pub enum BatchOperation {
     /// Read operation for a specific tag
-    /// 
+    ///
     /// # Fields
-    /// 
+    ///
     /// * `tag_name` - The name of the tag to read
     Read { tag_name: String },
-    
+
     /// Write operation for a specific tag with a value
-    /// 
+    ///
     /// # Fields
-    /// 
+    ///
     /// * `tag_name` - The name of the tag to write
     /// * `value` - The value to write to the tag
     Write { tag_name: String, value: PlcValue },
 }
 
 /// Result of a single operation in a batch request
-/// 
+///
 /// This structure contains the result of executing a single batch operation,
 /// including success/failure status and the actual data or error information.
 #[derive(Debug, Clone)]
 pub struct BatchResult {
     /// The original operation that was executed
     pub operation: BatchOperation,
-    
+
     /// The result of the operation
     pub result: std::result::Result<Option<PlcValue>, BatchError>,
-    
+
     /// Execution time for this specific operation (in microseconds)
     pub execution_time_us: u64,
 }
 
 /// Specific error types that can occur during batch operations
-/// 
+///
 /// This enum provides detailed error information for batch operations,
 /// allowing for better error handling and diagnostics.
 #[derive(Debug, Clone)]
 pub enum BatchError {
     /// Tag was not found in the PLC
     TagNotFound(String),
-    
+
     /// Data type mismatch between expected and actual
     DataTypeMismatch { expected: String, actual: String },
-    
+
     /// Network communication error
     NetworkError(String),
-    
+
     /// CIP protocol error with status code
     CipError { status: u8, message: String },
-    
+
     /// Tag name parsing error
     TagPathError(String),
-    
+
     /// Value serialization/deserialization error
     SerializationError(String),
-    
+
     /// Operation timeout
     Timeout,
-    
+
     /// Generic error for unexpected issues
     Other(String),
 }
@@ -314,7 +314,11 @@ impl std::fmt::Display for BatchError {
         match self {
             BatchError::TagNotFound(tag) => write!(f, "Tag not found: {}", tag),
             BatchError::DataTypeMismatch { expected, actual } => {
-                write!(f, "Data type mismatch: expected {}, got {}", expected, actual)
+                write!(
+                    f,
+                    "Data type mismatch: expected {}, got {}",
+                    expected, actual
+                )
             }
             BatchError::NetworkError(msg) => write!(f, "Network error: {}", msg),
             BatchError::CipError { status, message } => {
@@ -331,38 +335,38 @@ impl std::fmt::Display for BatchError {
 impl std::error::Error for BatchError {}
 
 /// Configuration for batch operations
-/// 
+///
 /// This structure controls the behavior and performance characteristics
 /// of batch read/write operations. Proper tuning can significantly
 /// improve throughput for applications that need to process many tags.
 #[derive(Debug, Clone)]
 pub struct BatchConfig {
     /// Maximum number of operations to include in a single CIP packet
-    /// 
+    ///
     /// Larger values improve performance but may exceed PLC packet size limits.
     /// Typical range: 10-50 operations per packet.
     pub max_operations_per_packet: usize,
-    
+
     /// Maximum packet size in bytes for batch operations
-    /// 
+    ///
     /// Should not exceed the PLC's maximum packet size capability.
     /// Typical values: 504 bytes (default), up to 4000 bytes for modern PLCs.
     pub max_packet_size: usize,
-    
+
     /// Timeout for individual batch packets (in milliseconds)
-    /// 
+    ///
     /// This is per-packet timeout, not per-operation.
     /// Typical range: 1000-5000 milliseconds.
     pub packet_timeout_ms: u64,
-    
+
     /// Whether to continue processing other operations if one fails
-    /// 
+    ///
     /// If true, failed operations are reported but don't stop the batch.
     /// If false, the first error stops the entire batch processing.
     pub continue_on_error: bool,
-    
+
     /// Whether to optimize packet packing by grouping similar operations
-    /// 
+    ///
     /// If true, reads and writes are grouped separately for better performance.
     /// If false, operations are processed in the order provided.
     pub optimize_packet_packing: bool,
@@ -372,7 +376,7 @@ impl Default for BatchConfig {
     fn default() -> Self {
         Self {
             max_operations_per_packet: 20,
-            max_packet_size: 504,  // Conservative default for maximum compatibility
+            max_packet_size: 504, // Conservative default for maximum compatibility
             packet_timeout_ms: 3000,
             continue_on_error: true,
             optimize_packet_packing: true,
@@ -381,47 +385,47 @@ impl Default for BatchConfig {
 }
 
 /// Connected session information for Class 3 explicit messaging
-/// 
+///
 /// Allen-Bradley PLCs often require connected sessions for certain operations
 /// like STRING writes. This structure maintains the connection state.
 #[derive(Debug, Clone)]
 pub struct ConnectedSession {
     /// Connection ID assigned by the PLC
     pub connection_id: u32,
-    
+
     /// Our connection ID (originator -> target)
     pub o_to_t_connection_id: u32,
-    
-    /// PLC's connection ID (target -> originator)  
+
+    /// PLC's connection ID (target -> originator)
     pub t_to_o_connection_id: u32,
-    
+
     /// Connection serial number for this session
     pub connection_serial: u16,
-    
+
     /// Originator vendor ID (our vendor ID)
     pub originator_vendor_id: u16,
-    
+
     /// Originator serial number (our serial number)
     pub originator_serial: u32,
-    
+
     /// Connection timeout multiplier
     pub timeout_multiplier: u8,
-    
+
     /// Requested Packet Interval (RPI) in microseconds
     pub rpi: u32,
-    
+
     /// Connection parameters for O->T direction
     pub o_to_t_params: ConnectionParameters,
-    
-    /// Connection parameters for T->O direction  
+
+    /// Connection parameters for T->O direction
     pub t_to_o_params: ConnectionParameters,
-    
+
     /// Timestamp when connection was established
     pub established_at: Instant,
-    
+
     /// Whether this connection is currently active
     pub is_active: bool,
-    
+
     /// Sequence counter for connected messages (increments with each message)
     pub sequence_count: u16,
 }
@@ -431,13 +435,13 @@ pub struct ConnectedSession {
 pub struct ConnectionParameters {
     /// Connection size in bytes
     pub size: u16,
-    
+
     /// Connection type (0x02 = Point-to-point, 0x01 = Multicast)
     pub connection_type: u8,
-    
+
     /// Priority (0x00 = Low, 0x01 = High, 0x02 = Scheduled, 0x03 = Urgent)
     pub priority: u8,
-    
+
     /// Variable size flag
     pub variable_size: bool,
 }
@@ -445,9 +449,9 @@ pub struct ConnectionParameters {
 impl Default for ConnectionParameters {
     fn default() -> Self {
         Self {
-            size: 500,              // 500 bytes default
-            connection_type: 0x02,  // Point-to-point
-            priority: 0x01,         // High priority
+            size: 500,             // 500 bytes default
+            connection_type: 0x02, // Point-to-point
+            priority: 0x01,        // High priority
             variable_size: false,
         }
     }
@@ -462,9 +466,9 @@ impl ConnectedSession {
             t_to_o_connection_id: 0,
             connection_serial,
             originator_vendor_id: 0x1337,  // Custom vendor ID
-            originator_serial: 0x12345678,  // Custom serial number
-            timeout_multiplier: 0x05,       // 32 seconds timeout
-            rpi: 100000,                    // 100ms RPI
+            originator_serial: 0x12345678, // Custom serial number
+            timeout_multiplier: 0x05,      // 32 seconds timeout
+            rpi: 100000,                   // 100ms RPI
             o_to_t_params: ConnectionParameters::default(),
             t_to_o_params: ConnectionParameters::default(),
             established_at: Instant::now(),
@@ -472,97 +476,97 @@ impl ConnectedSession {
             sequence_count: 0,
         }
     }
-    
+
     /// Creates a connected session with alternative parameters for different PLCs
     pub fn with_config(connection_serial: u16, config_id: u8) -> Self {
         let mut session = Self::new(connection_serial);
-        
+
         match config_id {
             1 => {
                 // Config 1: Conservative Allen-Bradley parameters
-                session.timeout_multiplier = 0x07;  // 256 seconds timeout
-                session.rpi = 200000;  // 200ms RPI (slower)
-                session.o_to_t_params.size = 504;   // Standard packet size
+                session.timeout_multiplier = 0x07; // 256 seconds timeout
+                session.rpi = 200000; // 200ms RPI (slower)
+                session.o_to_t_params.size = 504; // Standard packet size
                 session.t_to_o_params.size = 504;
-                session.o_to_t_params.priority = 0x00;  // Low priority
+                session.o_to_t_params.priority = 0x00; // Low priority
                 session.t_to_o_params.priority = 0x00;
                 println!("🔧 [CONFIG 1] Conservative: 504 bytes, 200ms RPI, low priority");
-            },
+            }
             2 => {
-                // Config 2: Compact parameters 
-                session.timeout_multiplier = 0x03;  // 8 seconds timeout
-                session.rpi = 50000;   // 50ms RPI (faster)
-                session.o_to_t_params.size = 256;   // Smaller packet size
+                // Config 2: Compact parameters
+                session.timeout_multiplier = 0x03; // 8 seconds timeout
+                session.rpi = 50000; // 50ms RPI (faster)
+                session.o_to_t_params.size = 256; // Smaller packet size
                 session.t_to_o_params.size = 256;
-                session.o_to_t_params.priority = 0x02;  // Scheduled priority
+                session.o_to_t_params.priority = 0x02; // Scheduled priority
                 session.t_to_o_params.priority = 0x02;
                 println!("🔧 [CONFIG 2] Compact: 256 bytes, 50ms RPI, scheduled priority");
-            },
+            }
             3 => {
                 // Config 3: Minimal parameters
-                session.timeout_multiplier = 0x01;  // 4 seconds timeout
+                session.timeout_multiplier = 0x01; // 4 seconds timeout
                 session.rpi = 1000000; // 1000ms RPI (very slow)
-                session.o_to_t_params.size = 128;   // Very small packets
+                session.o_to_t_params.size = 128; // Very small packets
                 session.t_to_o_params.size = 128;
-                session.o_to_t_params.priority = 0x03;  // Urgent priority
+                session.o_to_t_params.priority = 0x03; // Urgent priority
                 session.t_to_o_params.priority = 0x03;
                 println!("🔧 [CONFIG 3] Minimal: 128 bytes, 1000ms RPI, urgent priority");
-            },
+            }
             4 => {
                 // Config 4: Standard Rockwell parameters (from documentation)
-                session.timeout_multiplier = 0x05;  // 32 seconds timeout
-                session.rpi = 100000;  // 100ms RPI
-                session.o_to_t_params.size = 500;   // Standard size
+                session.timeout_multiplier = 0x05; // 32 seconds timeout
+                session.rpi = 100000; // 100ms RPI
+                session.o_to_t_params.size = 500; // Standard size
                 session.t_to_o_params.size = 500;
-                session.o_to_t_params.connection_type = 0x01;  // Multicast
+                session.o_to_t_params.connection_type = 0x01; // Multicast
                 session.t_to_o_params.connection_type = 0x01;
-                session.originator_vendor_id = 0x001D;  // Rockwell vendor ID
+                session.originator_vendor_id = 0x001D; // Rockwell vendor ID
                 println!("🔧 [CONFIG 4] Rockwell standard: 500 bytes, 100ms RPI, multicast, Rockwell vendor");
-            },
+            }
             5 => {
                 // Config 5: Large buffer parameters
-                session.timeout_multiplier = 0x0A;  // Very long timeout
-                session.rpi = 500000;  // 500ms RPI
-                session.o_to_t_params.size = 1024;  // Large packets
+                session.timeout_multiplier = 0x0A; // Very long timeout
+                session.rpi = 500000; // 500ms RPI
+                session.o_to_t_params.size = 1024; // Large packets
                 session.t_to_o_params.size = 1024;
-                session.o_to_t_params.variable_size = true;  // Variable size
+                session.o_to_t_params.variable_size = true; // Variable size
                 session.t_to_o_params.variable_size = true;
                 println!("🔧 [CONFIG 5] Large buffer: 1024 bytes, 500ms RPI, variable size");
-            },
+            }
             _ => {
                 // Default config
                 println!("🔧 [CONFIG 0] Default parameters");
             }
         }
-        
+
         session
     }
 }
 
 /// Represents the different data types supported by Allen-Bradley PLCs
-/// 
+///
 /// These correspond to the CIP data type codes used in EtherNet/IP
 /// communication. Each variant maps to a specific 16-bit type identifier
 /// that the PLC uses to describe tag data.
-/// 
+///
 /// # Supported Data Types
-/// 
+///
 /// ## Integer Types
 /// - **SINT**: 8-bit signed integer (-128 to 127)
 /// - **INT**: 16-bit signed integer (-32,768 to 32,767)
 /// - **DINT**: 32-bit signed integer (-2,147,483,648 to 2,147,483,647)
 /// - **LINT**: 64-bit signed integer (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807)
-/// 
+///
 /// ## Unsigned Integer Types
 /// - **USINT**: 8-bit unsigned integer (0 to 255)
 /// - **UINT**: 16-bit unsigned integer (0 to 65,535)
 /// - **UDINT**: 32-bit unsigned integer (0 to 4,294,967,295)
 /// - **ULINT**: 64-bit unsigned integer (0 to 18,446,744,073,709,551,615)
-/// 
+///
 /// ## Floating Point Types
 /// - **REAL**: 32-bit IEEE 754 float (±1.18 × 10^-38 to ±3.40 × 10^38)
 /// - **LREAL**: 64-bit IEEE 754 double (±2.23 × 10^-308 to ±1.80 × 10^308)
-/// 
+///
 /// ## Other Types
 /// - **BOOL**: Boolean value (true/false)
 /// - **STRING**: Variable-length string
@@ -570,81 +574,81 @@ impl ConnectedSession {
 #[derive(Debug, Clone, PartialEq)]
 pub enum PlcValue {
     /// Boolean value (single bit)
-    /// 
+    ///
     /// Maps to CIP type 0x00C1. In CompactLogix PLCs, BOOL tags
     /// are stored as single bits but transmitted as bytes over the network.
     Bool(bool),
-    
+
     /// 8-bit signed integer (-128 to 127)
-    /// 
+    ///
     /// Maps to CIP type 0x00C2. Used for small numeric values,
     /// status codes, and compact data storage.
     Sint(i8),
-    
+
     /// 16-bit signed integer (-32,768 to 32,767)
-    /// 
+    ///
     /// Maps to CIP type 0x00C3. Common for analog input/output values,
     /// counters, and medium-range numeric data.
     Int(i16),
-    
+
     /// 32-bit signed integer (-2,147,483,648 to 2,147,483,647)
-    /// 
+    ///
     /// Maps to CIP type 0x00C4. This is the most common integer type
     /// in Allen-Bradley PLCs, used for counters, setpoints, and numeric values.
     Dint(i32),
-    
+
     /// 64-bit signed integer (-9,223,372,036,854,775,808 to 9,223,372,036,854,775,807)
-    /// 
+    ///
     /// Maps to CIP type 0x00C5. Used for large counters, timestamps,
     /// and high-precision calculations.
     Lint(i64),
-    
+
     /// 8-bit unsigned integer (0 to 255)
-    /// 
+    ///
     /// Maps to CIP type 0x00C6. Used for byte data, small counters,
     /// and status flags.
     Usint(u8),
-    
+
     /// 16-bit unsigned integer (0 to 65,535)
-    /// 
+    ///
     /// Maps to CIP type 0x00C7. Common for analog values, port numbers,
     /// and medium-range unsigned data.
     Uint(u16),
-    
+
     /// 32-bit unsigned integer (0 to 4,294,967,295)
-    /// 
+    ///
     /// Maps to CIP type 0x00C8. Used for large counters, memory addresses,
     /// and unsigned calculations.
     Udint(u32),
-    
+
     /// 64-bit unsigned integer (0 to 18,446,744,073,709,551,615)
-    /// 
+    ///
     /// Maps to CIP type 0x00C9. Used for very large counters, timestamps,
     /// and high-precision unsigned calculations.
     Ulint(u64),
-    
+
     /// 32-bit IEEE 754 floating point number
-    /// 
+    ///
     /// Maps to CIP type 0x00CA. Used for analog values, calculations,
     /// and any data requiring decimal precision.
     /// Range: ±1.18 × 10^-38 to ±3.40 × 10^38
     Real(f32),
-    
+
     /// 64-bit IEEE 754 floating point number
-    /// 
+    ///
     /// Maps to CIP type 0x00CB. Used for high-precision calculations,
     /// scientific data, and extended-range floating point values.
     /// Range: ±2.23 × 10^-308 to ±1.80 × 10^308
     Lreal(f64),
-    
+
     /// String value
-    /// 
+    ///
     /// Maps to CIP type 0x00DA. Variable-length string data
     /// commonly used for product names, status messages, and text data.
     String(String),
-    
+
     /// User Defined Type instance
-    /// 
+    ///
     /// Maps to CIP type 0x00A0. Structured data type containing
     /// multiple members of different types.
     Udt(HashMap<String, PlcValue>),
@@ -652,10 +656,10 @@ pub enum PlcValue {
 
 impl PlcValue {
     /// Converts the PLC value to its byte representation for network transmission
-    /// 
+    ///
     /// This function handles the little-endian byte encoding required by
     /// the EtherNet/IP protocol. Each data type has specific encoding rules:
-    /// 
+    ///
     /// - BOOL: Single byte (0x00 = false, 0xFF = true)
     /// - SINT: Single signed byte
     /// - INT: 2 bytes in little-endian format
@@ -667,9 +671,9 @@ impl PlcValue {
     /// - ULINT: 8 bytes in little-endian format
     /// - REAL: 4 bytes IEEE 754 little-endian format
     /// - LREAL: 8 bytes IEEE 754 little-endian format
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A vector of bytes ready for transmission to the PLC
     pub fn to_bytes(&self) -> Vec<u8> {
         match self {
@@ -687,18 +691,18 @@ impl PlcValue {
             PlcValue::String(val) => {
                 // Try minimal approach - just length + data without padding
                 // Testing if the PLC accepts a simpler format
-                
+
                 let mut bytes = Vec::new();
-                
+
                 // Length field (4 bytes as DINT) - number of characters currently used
                 let length = val.len().min(82) as u32;
                 bytes.extend_from_slice(&length.to_le_bytes());
-                
+
                 // String data - just the actual characters, no padding
                 let string_bytes = val.as_bytes();
                 let data_len = string_bytes.len().min(82);
                 bytes.extend_from_slice(&string_bytes[..data_len]);
-                
+
                 bytes
             }
             PlcValue::Udt(_) => {
@@ -707,54 +711,54 @@ impl PlcValue {
             }
         }
     }
-    
+
     /// Returns the CIP data type code for this value
-    /// 
+    ///
     /// These codes are defined by the CIP specification and must match
     /// exactly what the PLC expects for each data type.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// The 16-bit CIP type code for this value type
     pub fn get_data_type(&self) -> u16 {
         match self {
-            PlcValue::Bool(_) => 0x00C1,  // BOOL
-            PlcValue::Sint(_) => 0x00C2,  // SINT (signed char)
-            PlcValue::Int(_) => 0x00C3,   // INT (short)
-            PlcValue::Dint(_) => 0x00C4,  // DINT (int)
-            PlcValue::Lint(_) => 0x00C5,  // LINT (long long)
-            PlcValue::Usint(_) => 0x00C6, // USINT (unsigned char)
-            PlcValue::Uint(_) => 0x00C7,  // UINT (unsigned short)
-            PlcValue::Udint(_) => 0x00C8, // UDINT (unsigned int)
-            PlcValue::Ulint(_) => 0x00C9, // ULINT (unsigned long long)
-            PlcValue::Real(_) => 0x00CA,  // REAL (float)
-            PlcValue::Lreal(_) => 0x00CB, // LREAL (double)
+            PlcValue::Bool(_) => 0x00C1,   // BOOL
+            PlcValue::Sint(_) => 0x00C2,   // SINT (signed char)
+            PlcValue::Int(_) => 0x00C3,    // INT (short)
+            PlcValue::Dint(_) => 0x00C4,   // DINT (int)
+            PlcValue::Lint(_) => 0x00C5,   // LINT (long long)
+            PlcValue::Usint(_) => 0x00C6,  // USINT (unsigned char)
+            PlcValue::Uint(_) => 0x00C7,   // UINT (unsigned short)
+            PlcValue::Udint(_) => 0x00C8,  // UDINT (unsigned int)
+            PlcValue::Ulint(_) => 0x00C9,  // ULINT (unsigned long long)
+            PlcValue::Real(_) => 0x00CA,   // REAL (float)
+            PlcValue::Lreal(_) => 0x00CB,  // LREAL (double)
             PlcValue::String(_) => 0x02A0, // Allen-Bradley STRING type (matches PLC read responses)
-            PlcValue::Udt(_) => 0x00A0,   // UDT placeholder
+            PlcValue::Udt(_) => 0x00A0,    // UDT placeholder
         }
     }
 }
 
 /// High-performance EtherNet/IP client for PLC communication
-/// 
+///
 /// This struct provides the core functionality for communicating with Allen-Bradley
 /// PLCs using the EtherNet/IP protocol. It handles connection management, session
 /// registration, and tag operations.
-/// 
+///
 /// # Thread Safety
-/// 
+///
 /// The `EipClient` is **NOT** thread-safe. For multi-threaded applications:
-/// 
+///
 /// ```rust,no_run
 /// use std::sync::Arc;
 /// use tokio::sync::Mutex;
 /// use rust_ethernet_ip::EipClient;
-/// 
+///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ///     // Create a thread-safe wrapper
 ///     let client = Arc::new(Mutex::new(EipClient::connect("192.168.1.100:44818").await?));
-/// 
+///
 ///     // Use in multiple threads
 ///     let client_clone = client.clone();
 ///     tokio::spawn(async move {
@@ -765,23 +769,23 @@ impl PlcValue {
 ///     Ok(())
 /// }
 /// ```
-/// 
+///
 /// # Performance Characteristics
-/// 
+///
 /// | Operation | Latency | Throughput | Memory |
 /// |-----------|---------|------------|---------|
 /// | Connect | 100-500ms | N/A | ~8KB |
 /// | Read Tag | 1-5ms | 1,500+ ops/sec | ~2KB |
 /// | Write Tag | 2-10ms | 600+ ops/sec | ~2KB |
 /// | Batch Read | 5-20ms | 2,000+ ops/sec | ~4KB |
-/// 
+///
 /// # Error Handling
-/// 
+///
 /// All operations return `Result<T, EtherNetIpError>`. Common errors include:
-/// 
+///
 /// ```rust,no_run
 /// use rust_ethernet_ip::{EipClient, EtherNetIpError};
-/// 
+///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
@@ -795,23 +799,23 @@ impl PlcValue {
 ///     Ok(())
 /// }
 /// ```
-/// 
+///
 /// # Examples
-/// 
+///
 /// Basic usage:
 /// ```rust,no_run
 /// use rust_ethernet_ip::{EipClient, PlcValue};
-/// 
+///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-/// 
+///
 ///     // Read a boolean tag
 ///     let motor_running = client.read_tag("MotorRunning").await?;
-/// 
+///
 ///     // Write an integer tag
 ///     client.write_tag("SetPoint", PlcValue::Dint(1500)).await?;
-/// 
+///
 ///     // Read multiple tags in sequence
 ///     let tag1 = client.read_tag("Tag1").await?;
 ///     let tag2 = client.read_tag("Tag2").await?;
@@ -819,12 +823,12 @@ impl PlcValue {
 ///     Ok(())
 /// }
 /// ```
-/// 
+///
 /// Advanced usage with error recovery:
 /// ```rust
 /// use rust_ethernet_ip::{EipClient, PlcValue, EtherNetIpError};
 /// use tokio::time::Duration;
-/// 
+///
 /// async fn read_with_retry(client: &mut EipClient, tag: &str, retries: u32) -> Result<PlcValue, EtherNetIpError> {
 ///     for attempt in 0..retries {
 ///         match client.read_tag(tag).await {
@@ -873,7 +877,8 @@ pub struct EipClient {
 
 impl EipClient {
     pub async fn new(addr: &str) -> Result<Self> {
-        let addr = addr.parse::<SocketAddr>()
+        let addr = addr
+            .parse::<SocketAddr>()
             .map_err(|e| EtherNetIpError::Protocol(format!("Invalid address format: {}", e)))?;
         let stream = TcpStream::connect(addr).await?;
         let mut client = Self {
@@ -899,43 +904,50 @@ impl EipClient {
     pub async fn connect(addr: &str) -> Result<Self> {
         Self::new(addr).await
     }
-    
+
     /// Registers an EtherNet/IP session with the PLC
-    /// 
+    ///
     /// This is an internal function that implements the EtherNet/IP session
     /// registration protocol. It sends a Register Session command and
     /// processes the response to extract the session handle.
-    /// 
+    ///
     /// # Protocol Details
-    /// 
+    ///
     /// The Register Session command consists of:
     /// - EtherNet/IP Encapsulation Header (24 bytes)
     /// - Registration Data (4 bytes: protocol version + options)
-    /// 
+    ///
     /// The PLC responds with:
     /// - Same header format with assigned session handle
     /// - Status code indicating success/failure
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// - Network timeout or disconnection
     /// - Invalid response format
     /// - PLC rejection (status code non-zero)
     async fn register_session(&mut self) -> crate::error::Result<()> {
         println!("🔌 [DEBUG] Starting session registration...");
         let packet: [u8; 28] = [
-            0x65, 0x00,             // Command: Register Session (0x0065)
-            0x04, 0x00,             // Length: 4 bytes
+            0x65, 0x00, // Command: Register Session (0x0065)
+            0x04, 0x00, // Length: 4 bytes
             0x00, 0x00, 0x00, 0x00, // Session Handle: 0 (will be assigned)
             0x00, 0x00, 0x00, 0x00, // Status: 0
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Sender Context (8 bytes)
             0x00, 0x00, 0x00, 0x00, // Options: 0
-            0x01, 0x00,             // Protocol Version: 1
-            0x00, 0x00,             // Option Flags: 0
+            0x01, 0x00, // Protocol Version: 1
+            0x00, 0x00, // Option Flags: 0
         ];
 
-        println!("📤 [DEBUG] Sending Register Session packet: {:02X?}", packet);
-        self.stream.lock().await.write_all(&packet).await
+        println!(
+            "📤 [DEBUG] Sending Register Session packet: {:02X?}",
+            packet
+        );
+        self.stream
+            .lock()
+            .await
+            .write_all(&packet)
+            .await
             .map_err(|e| {
                 println!("❌ [DEBUG] Failed to send Register Session packet: {}", e);
                 EtherNetIpError::Io(e)
@@ -943,19 +955,24 @@ impl EipClient {
 
         let mut buf = [0u8; 1024];
         println!("⏳ [DEBUG] Waiting for Register Session response...");
-        let n = match timeout(Duration::from_secs(5), self.stream.lock().await.read(&mut buf)).await {
+        let n = match timeout(
+            Duration::from_secs(5),
+            self.stream.lock().await.read(&mut buf),
+        )
+        .await
+        {
             Ok(Ok(n)) => {
                 println!("📥 [DEBUG] Received {} bytes in response", n);
                 n
-            },
+            }
             Ok(Err(e)) => {
                 println!("❌ [DEBUG] Error reading response: {}", e);
                 return Err(EtherNetIpError::Io(e));
-            },
+            }
             Err(_) => {
                 println!("⏰ [DEBUG] Timeout waiting for response");
                 return Err(EtherNetIpError::Timeout(Duration::from_secs(5)));
-            },
+            }
         };
 
         if n < 28 {
@@ -966,28 +983,36 @@ impl EipClient {
         // Extract session handle from response
         self.session_handle = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
         println!("🔑 [DEBUG] Session handle: 0x{:08X}", self.session_handle);
-        
+
         // Check status
         let status = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
         println!("📊 [DEBUG] Status code: 0x{:08X}", status);
-        
+
         if status != 0 {
-            println!("❌ [DEBUG] Session registration failed with status: 0x{:08X}", status);
-            return Err(EtherNetIpError::Protocol(format!("Session registration failed with status: 0x{:08X}", status)));
+            println!(
+                "❌ [DEBUG] Session registration failed with status: 0x{:08X}",
+                status
+            );
+            return Err(EtherNetIpError::Protocol(format!(
+                "Session registration failed with status: 0x{:08X}",
+                status
+            )));
         }
 
         println!("✅ [DEBUG] Session registration successful");
         Ok(())
     }
-    
+
     /// Sets the maximum packet size for communication
     pub fn set_max_packet_size(&mut self, size: u32) {
         self.max_packet_size = size.min(4000);
     }
-    
+
     /// Discovers all tags in the PLC
     pub async fn discover_tags(&mut self) -> crate::error::Result<()> {
-        let response = self.send_cip_request(&self.build_list_tags_request()).await?;
+        let response = self
+            .send_cip_request(&self.build_list_tags_request())
+            .await?;
         let tags = self.tag_manager.lock().await.parse_tag_list(&response)?;
         let tag_manager = self.tag_manager.lock().await;
         let mut cache = tag_manager.cache.write().unwrap();
@@ -996,7 +1021,7 @@ impl EipClient {
         }
         Ok(())
     }
-    
+
     /// Gets metadata for a tag
     pub async fn get_tag_metadata(&self, tag_name: &str) -> Option<TagMetadata> {
         let tag_manager = self.tag_manager.lock().await;
@@ -1004,34 +1029,34 @@ impl EipClient {
         let result = cache.get(tag_name).cloned();
         result
     }
-    
+
     /// Reads a tag value from the PLC
-    /// 
+    ///
     /// This function performs a CIP read request for the specified tag.
     /// The tag's data type is automatically determined from the PLC's response.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_name` - The name of the tag to read
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// The tag's value as a `PlcValue` enum
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,no_run
     /// use rust_ethernet_ip::{EipClient, PlcValue};
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-    ///     
+    ///
     ///     // Read different data types
     ///     let bool_val = client.read_tag("MotorRunning").await?;
     ///     let int_val = client.read_tag("Counter").await?;
     ///     let real_val = client.read_tag("Temperature").await?;
-    ///     
+    ///
     ///     // Handle the result
     ///     match bool_val {
     ///         PlcValue::Bool(true) => println!("Motor is running"),
@@ -1041,15 +1066,15 @@ impl EipClient {
     ///     Ok(())
     /// }
     /// ```
-    /// 
+    ///
     /// # Performance
-    /// 
+    ///
     /// - Latency: 1-5ms typical
     /// - Throughput: 1,500+ ops/sec
     /// - Network: 1 request/response cycle
-    /// 
+    ///
     /// # Error Handling
-    /// 
+    ///
     /// Common errors:
     /// - `Protocol`: Tag doesn't exist or invalid format
     /// - `Connection`: Lost connection to PLC
@@ -1061,237 +1086,280 @@ impl EipClient {
             // Handle UDT tags
             if metadata.data_type == 0x00A0 {
                 let data = self.read_tag_raw(tag_name).await?;
-                return self.udt_manager.lock().await.parse_udt_instance(tag_name, &data);
+                return self
+                    .udt_manager
+                    .lock()
+                    .await
+                    .parse_udt_instance(tag_name, &data);
             }
         }
 
         // Standard tag reading
-        let response = self.send_cip_request(&self.build_read_request(tag_name)).await?;
+        let response = self
+            .send_cip_request(&self.build_read_request(tag_name))
+            .await?;
         let cip_data = self.extract_cip_from_response(&response)?;
         self.parse_cip_response(&cip_data)
     }
-    
+
     /// Writes a value to a PLC tag
-    /// 
+    ///
     /// This method automatically determines the best communication method based on the data type:
     /// - STRING values use unconnected explicit messaging with proper AB STRING format
     /// - Other data types use standard unconnected messaging
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_name` - The name of the tag to write to
     /// * `value` - The value to write
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```no_run
     /// # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     /// # let mut client = rust_ethernet_ip::EipClient::connect("192.168.1.100:44818").await?;
     /// use rust_ethernet_ip::PlcValue;
-    /// 
+    ///
     /// client.write_tag("Counter", PlcValue::Dint(42)).await?;
     /// client.write_tag("Message", PlcValue::String("Hello PLC".to_string())).await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn write_tag(&mut self, tag_name: &str, value: PlcValue) -> crate::error::Result<()> {
-        println!("📝 Writing '{}' to tag '{}'", 
-                 match &value {
-                     PlcValue::String(s) => format!("\"{}\"", s),
-                     _ => format!("{:?}", value),
-                 }, 
-                 tag_name);
-        
+        println!(
+            "📝 Writing '{}' to tag '{}'",
+            match &value {
+                PlcValue::String(s) => format!("\"{}\"", s),
+                _ => format!("{:?}", value),
+            },
+            tag_name
+        );
+
         // Use specialized AB STRING format for STRING writes (required for proper Allen-Bradley STRING handling)
         // All data types including strings now use the standard write path
         // The PlcValue::to_bytes() method handles the correct format for each type
-        
+
         // Use standard unconnected messaging for other data types
         let cip_request = self.build_write_request(tag_name, &value)?;
-        
+
         let response = self.send_cip_request(&cip_request).await?;
-        
+
         // Check write response for errors - need to extract CIP response first
         let cip_response = self.extract_cip_from_response(&response)?;
-        
+
         if cip_response.len() < 3 {
-            return Err(EtherNetIpError::Protocol("Write response too short".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Write response too short".to_string(),
+            ));
         }
-        
-        let service_reply = cip_response[0];  // Should be 0xCD (0x4D + 0x80) for Write Tag reply
+
+        let service_reply = cip_response[0]; // Should be 0xCD (0x4D + 0x80) for Write Tag reply
         let general_status = cip_response[2]; // CIP status code
-        
-        println!("🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}", service_reply, general_status);
-        
+
+        println!(
+            "🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}",
+            service_reply, general_status
+        );
+
         if general_status != 0x00 {
             let error_msg = self.get_cip_error_message(general_status);
-            println!("❌ [WRITE] CIP Error: {} (0x{:02X})", error_msg, general_status);
-            return Err(EtherNetIpError::Protocol(format!("CIP Error 0x{:02X}: {}", general_status, error_msg)));
+            println!(
+                "❌ [WRITE] CIP Error: {} (0x{:02X})",
+                error_msg, general_status
+            );
+            return Err(EtherNetIpError::Protocol(format!(
+                "CIP Error 0x{:02X}: {}",
+                general_status, error_msg
+            )));
         }
-        
+
         println!("✅ Write operation completed successfully");
         Ok(())
     }
 
-    /// Builds a write request specifically for Allen-Bradley string format 
-    fn _build_ab_string_write_request(&self, tag_name: &str, value: &PlcValue) -> crate::error::Result<Vec<u8>> {
+    /// Builds a write request specifically for Allen-Bradley string format
+    fn _build_ab_string_write_request(
+        &self,
+        tag_name: &str,
+        value: &PlcValue,
+    ) -> crate::error::Result<Vec<u8>> {
         if let PlcValue::String(string_value) = value {
-            println!("🔧 [DEBUG] Building correct Allen-Bradley string write request for tag: '{}'", tag_name);
-            
+            println!(
+                "🔧 [DEBUG] Building correct Allen-Bradley string write request for tag: '{}'",
+                tag_name
+            );
+
             let mut cip_request = Vec::new();
-            
+
             // Service: Write Tag Service (0x4D)
             cip_request.push(0x4D);
-            
+
             // Request Path Size (in words)
             let tag_bytes = tag_name.as_bytes();
-            let path_len = if tag_bytes.len() % 2 == 0 { 
-                tag_bytes.len() + 2 
-            } else { 
-                tag_bytes.len() + 3 
+            let path_len = if tag_bytes.len() % 2 == 0 {
+                tag_bytes.len() + 2
+            } else {
+                tag_bytes.len() + 3
             } / 2;
             cip_request.push(path_len as u8);
-            
+
             // Request Path
             cip_request.push(0x91); // ANSI Extended Symbol
             cip_request.push(tag_bytes.len() as u8);
             cip_request.extend_from_slice(tag_bytes);
-            
+
             // Pad to word boundary if needed
             if tag_bytes.len() % 2 != 0 {
                 cip_request.push(0x00);
             }
-            
+
             // Data Type: Allen-Bradley STRING (0x02A0)
             cip_request.extend_from_slice(&[0xA0, 0x02]);
-            
+
             // Element Count (always 1 for single string)
             cip_request.extend_from_slice(&[0x01, 0x00]);
-            
+
             // Build the correct AB STRING structure
             let string_bytes = string_value.as_bytes();
             let max_len: u16 = 82; // Standard AB STRING max length
             let current_len = string_bytes.len().min(max_len as usize) as u16;
-            
+
             // AB STRING structure:
             // - Len (2 bytes) - number of characters used
             cip_request.extend_from_slice(&current_len.to_le_bytes());
-            
-            // - MaxLen (2 bytes) - maximum characters allowed (typically 82)  
+
+            // - MaxLen (2 bytes) - maximum characters allowed (typically 82)
             cip_request.extend_from_slice(&max_len.to_le_bytes());
-            
+
             // - Data[MaxLen] (82 bytes) - the character array, zero-padded
             let mut data_array = vec![0u8; max_len as usize];
-            data_array[..current_len as usize].copy_from_slice(&string_bytes[..current_len as usize]);
+            data_array[..current_len as usize]
+                .copy_from_slice(&string_bytes[..current_len as usize]);
             cip_request.extend_from_slice(&data_array);
-            
-            println!("🔧 [DEBUG] Built correct AB string write request ({} bytes): len={}, maxlen={}, data_len={}", 
+
+            println!("🔧 [DEBUG] Built correct AB string write request ({} bytes): len={}, maxlen={}, data_len={}",
                      cip_request.len(), current_len, max_len, string_bytes.len());
-            println!("🔧 [DEBUG] First 32 bytes: {:02X?}", &cip_request[..std::cmp::min(32, cip_request.len())]);
-            
+            println!(
+                "🔧 [DEBUG] First 32 bytes: {:02X?}",
+                &cip_request[..std::cmp::min(32, cip_request.len())]
+            );
+
             Ok(cip_request)
         } else {
-            Err(EtherNetIpError::Protocol("Expected string value for Allen-Bradley string write".to_string()))
+            Err(EtherNetIpError::Protocol(
+                "Expected string value for Allen-Bradley string write".to_string(),
+            ))
         }
     }
 
     /// Builds a CIP Write Tag Service request
-    /// 
+    ///
     /// This creates the CIP packet for writing a value to a tag.
     /// The request includes the service code, tag path, data type, and value.
-    fn build_write_request(&self, tag_name: &str, value: &PlcValue) -> crate::error::Result<Vec<u8>> {
+    fn build_write_request(
+        &self,
+        tag_name: &str,
+        value: &PlcValue,
+    ) -> crate::error::Result<Vec<u8>> {
         println!("🔧 [DEBUG] Building write request for tag: '{}'", tag_name);
-        
+
         // Use Connected Explicit Messaging for consistency
         let mut cip_request = Vec::new();
-        
+
         // Service: Write Tag Service (0x4D)
         cip_request.push(0x4D);
-        
+
         // Request Path Size (in words)
         let tag_bytes = tag_name.as_bytes();
-        let path_len = if tag_bytes.len() % 2 == 0 { 
-            tag_bytes.len() + 2 
-        } else { 
-            tag_bytes.len() + 3 
+        let path_len = if tag_bytes.len() % 2 == 0 {
+            tag_bytes.len() + 2
+        } else {
+            tag_bytes.len() + 3
         };
         cip_request.push((path_len / 2) as u8);
-        
+
         // Request Path: ANSI Extended Symbol Segment for tag name
         cip_request.push(0x91); // ANSI Extended Symbol Segment
         cip_request.push(tag_bytes.len() as u8); // Tag name length
         cip_request.extend_from_slice(tag_bytes); // Tag name
-        
+
         // Pad to even length if necessary
         if tag_bytes.len() % 2 != 0 {
             cip_request.push(0x00);
         }
-        
+
         // Add data type and element count
         let data_type = value.get_data_type();
         let value_bytes = value.to_bytes();
-        
+
         cip_request.extend_from_slice(&data_type.to_le_bytes()); // Data type
         cip_request.extend_from_slice(&[0x01, 0x00]); // Element count: 1
         cip_request.extend_from_slice(&value_bytes); // Value data
-        
-        println!("🔧 [DEBUG] Built CIP write request ({} bytes): {:02X?}", 
-                 cip_request.len(), cip_request);
+
+        println!(
+            "🔧 [DEBUG] Built CIP write request ({} bytes): {:02X?}",
+            cip_request.len(),
+            cip_request
+        );
         Ok(cip_request)
     }
 
     /// Builds a raw write request with pre-serialized data
-    fn build_write_request_raw(&self, tag_name: &str, data: &[u8]) -> crate::error::Result<Vec<u8>> {
+    fn build_write_request_raw(
+        &self,
+        tag_name: &str,
+        data: &[u8],
+    ) -> crate::error::Result<Vec<u8>> {
         let mut request = Vec::new();
-        
+
         // Write Tag Service
         request.push(0x4D);
         request.push(0x00);
-        
-        // Build tag path  
+
+        // Build tag path
         let tag_path = self.build_tag_path(tag_name);
         request.extend(tag_path);
-        
+
         // Add raw data
         request.extend(data);
-        
+
         Ok(request)
     }
 
     /// Builds the CIP tag path for a given tag name
-    /// 
+    ///
     /// This function converts a human-readable tag name into the binary
     /// path format required by the CIP protocol. The path consists of
     /// segments that describe how to navigate to the tag in the PLC's
     /// tag database.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_name` - The tag name to convert to a path
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A vector of bytes representing the CIP path
     fn build_tag_path(&self, tag_name: &str) -> Vec<u8> {
         // Use simple tag path for now
         self.build_simple_tag_path(tag_name)
     }
-    
+
     /// Builds a simple tag path for basic tag names (fallback method)
     fn build_simple_tag_path(&self, tag_name: &str) -> Vec<u8> {
         let mut path = Vec::new();
         let tag_bytes = tag_name.as_bytes();
-        
+
         // ANSI Extended Symbol Segment
         path.push(0x91);
         path.push(tag_bytes.len() as u8);
         path.extend_from_slice(tag_bytes);
-        
+
         // Pad to even length if necessary
         if (tag_bytes.len() + 1) % 2 != 0 {
             path.push(0x00);
         }
-        
+
         path
     }
 
@@ -1299,7 +1367,7 @@ impl EipClient {
     #[allow(dead_code)]
     fn serialize_value(&self, value: &PlcValue) -> crate::error::Result<Vec<u8>> {
         let mut data = Vec::new();
-        
+
         match value {
             PlcValue::Bool(v) => {
                 data.extend(&0x00C1u16.to_le_bytes()); // Data type
@@ -1347,16 +1415,16 @@ impl EipClient {
             }
             PlcValue::String(v) => {
                 data.extend(&0x00CEu16.to_le_bytes()); // Data type - correct Allen-Bradley STRING CIP type
-                
+
                 // Length field (4 bytes as DINT) - number of characters currently used
                 let length = v.len().min(82) as u32;
                 data.extend_from_slice(&length.to_le_bytes());
-                
+
                 // String data - the actual characters (no MaxLen field)
                 let string_bytes = v.as_bytes();
                 let data_len = string_bytes.len().min(82);
                 data.extend_from_slice(&string_bytes[..data_len]);
-                
+
                 // Padding to make total data area exactly 82 bytes after length
                 let remaining_chars = 82 - data_len;
                 data.extend(vec![0u8; remaining_chars]);
@@ -1367,44 +1435,47 @@ impl EipClient {
                 data.extend(&0x00A0u16.to_le_bytes()); // UDT type code
             }
         }
-        
+
         Ok(data)
     }
 
     pub fn build_list_tags_request(&self) -> Vec<u8> {
         println!("🔧 [DEBUG] Building list tags request");
-        
+
         // Use Connected Explicit Messaging for consistency
-        let mut cip_request = Vec::new();
-        
+        let mut cip_request = Vec::with_capacity(8);
+
         // Service: List All Tags Service (0x55)
         cip_request.push(0x55);
-        
-        // Request Path Size (in words) - 3 words = 6 bytes  
+
+        // Request Path Size (in words) - 3 words = 6 bytes
         cip_request.push(0x03);
-        
+
         // Request Path: Class 0x6B (Symbol Object), Instance 1
         cip_request.push(0x20); // Class segment identifier
         cip_request.push(0x6B); // Symbol Object Class
         cip_request.push(0x24); // Instance segment identifier
         cip_request.push(0x01); // Instance 1
-        cip_request.push(0x01); // Attribute segment identifier  
+        cip_request.push(0x01); // Attribute segment identifier
         cip_request.push(0x00); // Attribute 0 (tag list)
-        
-        println!("🔧 [DEBUG] Built CIP list tags request ({} bytes): {:02X?}", 
-                 cip_request.len(), cip_request);
-        
+
+        println!(
+            "🔧 [DEBUG] Built CIP list tags request ({} bytes): {:02X?}",
+            cip_request.len(),
+            cip_request
+        );
+
         cip_request
     }
 
     /// Gets a human-readable error message for a CIP status code
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `status` - The CIP status code to look up
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A string describing the error
     fn get_cip_error_message(&self, status: u8) -> String {
         match status {
@@ -1453,18 +1524,18 @@ impl EipClient {
             0x2A => "Group 2 only server general failure".to_string(),
             0x2B => "Unknown Modbus error".to_string(),
             0x2C => "Attribute not gettable".to_string(),
-            _ => format!("Unknown CIP error code: 0x{:02X}", status)
+            _ => format!("Unknown CIP error code: 0x{:02X}", status),
         }
     }
 
     async fn validate_session(&mut self) -> crate::error::Result<()> {
         let time_since_activity = self.last_activity.lock().await.elapsed();
-        
+
         // Send keep-alive if it's been more than 30 seconds since last activity
         if time_since_activity > Duration::from_secs(30) {
             self.send_keep_alive().await?;
         }
-        
+
         Ok(())
     }
 
@@ -1473,7 +1544,7 @@ impl EipClient {
             0x6F, 0x00, // Command: SendRRData
             0x00, 0x00, // Length: 0
         ];
-        
+
         let mut stream = self.stream.lock().await;
         stream.write_all(&packet).await?;
         *self.last_activity.lock().await = Instant::now();
@@ -1483,15 +1554,16 @@ impl EipClient {
     /// Checks the health of the connection
     pub async fn check_health(&self) -> bool {
         // Check if we have a valid session handle and recent activity
-        self.session_handle != 0 && self.last_activity.lock().await.elapsed() < Duration::from_secs(150)
+        self.session_handle != 0
+            && self.last_activity.lock().await.elapsed() < Duration::from_secs(150)
     }
-    
+
     /// Performs a more thorough health check by actually communicating with the PLC
     pub async fn check_health_detailed(&mut self) -> crate::error::Result<bool> {
         if self.session_handle == 0 {
             return Ok(false);
         }
-        
+
         // Try sending a lightweight keep-alive command
         match self.send_keep_alive().await {
             Ok(()) => Ok(true),
@@ -1507,8 +1579,10 @@ impl EipClient {
 
     /// Reads raw data from a tag
     async fn read_tag_raw(&mut self, tag_name: &str) -> crate::error::Result<Vec<u8>> {
-        let response = self.send_cip_request(&self.build_read_request(tag_name)).await?;
-        Ok(self.extract_cip_from_response(&response)?)
+        let response = self
+            .send_cip_request(&self.build_read_request(tag_name))
+            .await?;
+        self.extract_cip_from_response(&response)
     }
 
     /// Writes raw data to a tag
@@ -1516,39 +1590,54 @@ impl EipClient {
     async fn write_tag_raw(&mut self, tag_name: &str, data: &[u8]) -> crate::error::Result<()> {
         let request = self.build_write_request_raw(tag_name, data)?;
         let response = self.send_cip_request(&request).await?;
-        
+
         // Check write response for errors
         let cip_response = self.extract_cip_from_response(&response)?;
-        
+
         if cip_response.len() < 3 {
-            return Err(EtherNetIpError::Protocol("Write response too short".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Write response too short".to_string(),
+            ));
         }
-        
-        let service_reply = cip_response[0];  // Should be 0xCD (0x4D + 0x80) for Write Tag reply
+
+        let service_reply = cip_response[0]; // Should be 0xCD (0x4D + 0x80) for Write Tag reply
         let general_status = cip_response[2]; // CIP status code
-        
-        println!("🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}", service_reply, general_status);
-        
+
+        println!(
+            "🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}",
+            service_reply, general_status
+        );
+
         if general_status != 0x00 {
             let error_msg = self.get_cip_error_message(general_status);
-            println!("❌ [WRITE] CIP Error: {} (0x{:02X})", error_msg, general_status);
-            return Err(EtherNetIpError::Protocol(format!("CIP Error 0x{:02X}: {}", general_status, error_msg)));
+            println!(
+                "❌ [WRITE] CIP Error: {} (0x{:02X})",
+                error_msg, general_status
+            );
+            return Err(EtherNetIpError::Protocol(format!(
+                "CIP Error 0x{:02X}: {}",
+                general_status, error_msg
+            )));
         }
-        
+
         println!("✅ Write completed successfully");
         Ok(())
     }
 
     /// Sends a CIP request wrapped in EtherNet/IP SendRRData command
     pub async fn send_cip_request(&self, cip_request: &[u8]) -> Result<Vec<u8>> {
-        println!("🔧 [DEBUG] Sending CIP request ({} bytes): {:02X?}", cip_request.len(), cip_request);
-        
+        println!(
+            "🔧 [DEBUG] Sending CIP request ({} bytes): {:02X?}",
+            cip_request.len(),
+            cip_request
+        );
+
         // Calculate total packet size
         let cip_data_size = cip_request.len();
         let total_data_len = 4 + 2 + 2 + 8 + cip_data_size; // Interface + Timeout + Count + Items + CIP
-        
+
         let mut packet = Vec::new();
-        
+
         // EtherNet/IP header (24 bytes)
         packet.extend_from_slice(&[0x6F, 0x00]); // Command: Send RR Data (0x006F)
         packet.extend_from_slice(&(total_data_len as u16).to_le_bytes()); // Length
@@ -1556,107 +1645,141 @@ impl EipClient {
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Status
         packet.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]); // Context
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Options
-        
+
         // CPF (Common Packet Format) data
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Interface handle
         packet.extend_from_slice(&[0x05, 0x00]); // Timeout (5 seconds)
         packet.extend_from_slice(&[0x02, 0x00]); // Item count: 2
-        
+
         // Item 1: Null Address Item (0x0000)
         packet.extend_from_slice(&[0x00, 0x00]); // Type: Null Address
         packet.extend_from_slice(&[0x00, 0x00]); // Length: 0
-        
+
         // Item 2: Unconnected Data Item (0x00B2)
         packet.extend_from_slice(&[0xB2, 0x00]); // Type: Unconnected Data
         packet.extend_from_slice(&(cip_data_size as u16).to_le_bytes()); // Length
-        
+
         // Add CIP request data
         packet.extend_from_slice(cip_request);
-        
-        println!("🔧 [DEBUG] Built packet ({} bytes): {:02X?}", packet.len(), &packet[..std::cmp::min(64, packet.len())]);
-        
+
+        println!(
+            "🔧 [DEBUG] Built packet ({} bytes): {:02X?}",
+            packet.len(),
+            &packet[..std::cmp::min(64, packet.len())]
+        );
+
         // Send packet with timeout
         let mut stream = self.stream.lock().await;
-        stream.write_all(&packet).await
-            .map_err(|e| EtherNetIpError::Io(e))?;
-        
+        stream
+            .write_all(&packet)
+            .await
+            .map_err(EtherNetIpError::Io)?;
+
         // Read response header with timeout
         let mut header = [0u8; 24];
         match timeout(Duration::from_secs(10), stream.read_exact(&mut header)).await {
-            Ok(Ok(_)) => {},
+            Ok(Ok(_)) => {}
             Ok(Err(e)) => return Err(EtherNetIpError::Io(e)),
             Err(_) => return Err(EtherNetIpError::Timeout(Duration::from_secs(10))),
         }
-        
+
         // Check EtherNet/IP command status
         let cmd_status = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
         if cmd_status != 0 {
-            return Err(EtherNetIpError::Protocol(format!("EIP Command failed. Status: 0x{:08X}", cmd_status)));
+            return Err(EtherNetIpError::Protocol(format!(
+                "EIP Command failed. Status: 0x{:08X}",
+                cmd_status
+            )));
         }
-        
+
         // Parse response length
         let response_length = u16::from_le_bytes([header[2], header[3]]) as usize;
         if response_length == 0 {
             return Ok(Vec::new());
         }
-        
+
         // Read response data with timeout
         let mut response_data = vec![0u8; response_length];
-        match timeout(Duration::from_secs(10), stream.read_exact(&mut response_data)).await {
-            Ok(Ok(_)) => {},
+        match timeout(
+            Duration::from_secs(10),
+            stream.read_exact(&mut response_data),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
             Ok(Err(e)) => return Err(EtherNetIpError::Io(e)),
             Err(_) => return Err(EtherNetIpError::Timeout(Duration::from_secs(10))),
         }
-        
+
         // Update last activity time
         *self.last_activity.lock().await = Instant::now();
-        
-        println!("🔧 [DEBUG] Received response ({} bytes): {:02X?}", 
-                 response_data.len(), &response_data[..std::cmp::min(32, response_data.len())]);
-        
+
+        println!(
+            "🔧 [DEBUG] Received response ({} bytes): {:02X?}",
+            response_data.len(),
+            &response_data[..std::cmp::min(32, response_data.len())]
+        );
+
         Ok(response_data)
     }
 
     /// Extracts CIP data from EtherNet/IP response packet
     fn extract_cip_from_response(&self, response: &[u8]) -> crate::error::Result<Vec<u8>> {
-        println!("🔧 [DEBUG] Extracting CIP from response ({} bytes): {:02X?}", 
-                 response.len(), &response[..std::cmp::min(32, response.len())]);
-        
+        println!(
+            "🔧 [DEBUG] Extracting CIP from response ({} bytes): {:02X?}",
+            response.len(),
+            &response[..std::cmp::min(32, response.len())]
+        );
+
         // Parse CPF (Common Packet Format) structure directly from response data
         // Response format: [Interface(4)] [Timeout(2)] [ItemCount(2)] [Items...]
-        
+
         if response.len() < 8 {
-            return Err(EtherNetIpError::Protocol("Response too short for CPF header".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Response too short for CPF header".to_string(),
+            ));
         }
 
         // Skip interface handle (4 bytes) and timeout (2 bytes)
         let mut pos = 6;
-        
+
         // Read item count
-        let item_count = u16::from_le_bytes([response[pos], response[pos+1]]);
+        let item_count = u16::from_le_bytes([response[pos], response[pos + 1]]);
         pos += 2;
         println!("🔧 [DEBUG] CPF item count: {}", item_count);
 
         // Process items
         for i in 0..item_count {
             if pos + 4 > response.len() {
-                return Err(EtherNetIpError::Protocol("Response truncated while parsing items".to_string()));
+                return Err(EtherNetIpError::Protocol(
+                    "Response truncated while parsing items".to_string(),
+                ));
             }
 
             let item_type = u16::from_le_bytes([response[pos], response[pos + 1]]);
             let item_length = u16::from_le_bytes([response[pos + 2], response[pos + 3]]) as usize;
             pos += 4; // Skip item header
 
-            println!("🔧 [DEBUG] Item {}: type=0x{:04X}, length={}", i, item_type, item_length);
+            println!(
+                "🔧 [DEBUG] Item {}: type=0x{:04X}, length={}",
+                i, item_type, item_length
+            );
 
-            if item_type == 0x00B2 { // Unconnected Data Item
+            if item_type == 0x00B2 {
+                // Unconnected Data Item
                 if pos + item_length > response.len() {
                     return Err(EtherNetIpError::Protocol("Data item truncated".to_string()));
                 }
 
                 let cip_data = response[pos..pos + item_length].to_vec();
-                println!("🔧 [DEBUG] Found Unconnected Data Item, extracted CIP data ({} bytes)", cip_data.len());
-                println!("🔧 [DEBUG] CIP data bytes: {:02X?}", &cip_data[..std::cmp::min(16, cip_data.len())]);
+                println!(
+                    "🔧 [DEBUG] Found Unconnected Data Item, extracted CIP data ({} bytes)",
+                    cip_data.len()
+                );
+                println!(
+                    "🔧 [DEBUG] CIP data bytes: {:02X?}",
+                    &cip_data[..std::cmp::min(16, cip_data.len())]
+                );
                 return Ok(cip_data);
             } else {
                 // Skip this item's data
@@ -1664,143 +1787,201 @@ impl EipClient {
             }
         }
 
-        Err(EtherNetIpError::Protocol("No Unconnected Data Item (0x00B2) found in response".to_string()))
+        Err(EtherNetIpError::Protocol(
+            "No Unconnected Data Item (0x00B2) found in response".to_string(),
+        ))
     }
 
     /// Parses CIP response and converts to PlcValue
     fn parse_cip_response(&self, cip_response: &[u8]) -> crate::error::Result<PlcValue> {
-        println!("🔧 [DEBUG] Parsing CIP response ({} bytes): {:02X?}", cip_response.len(), cip_response);
-        
+        println!(
+            "🔧 [DEBUG] Parsing CIP response ({} bytes): {:02X?}",
+            cip_response.len(),
+            cip_response
+        );
+
         if cip_response.len() < 2 {
-            return Err(EtherNetIpError::Protocol("CIP response too short".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "CIP response too short".to_string(),
+            ));
         }
 
-        let service_reply = cip_response[0];    // Should be 0xCC (0x4C + 0x80) for Read Tag reply
-        let general_status = cip_response[2];   // CIP status code
-        
-        println!("🔧 [DEBUG] Service reply: 0x{:02X}, Status: 0x{:02X}", 
-                 service_reply, general_status);
+        let service_reply = cip_response[0]; // Should be 0xCC (0x4C + 0x80) for Read Tag reply
+        let general_status = cip_response[2]; // CIP status code
 
-        // Check for CIP errors  
+        println!(
+            "🔧 [DEBUG] Service reply: 0x{:02X}, Status: 0x{:02X}",
+            service_reply, general_status
+        );
+
+        // Check for CIP errors
         if general_status != 0x00 {
             let error_msg = self.get_cip_error_message(general_status);
-            println!("🔧 [DEBUG] CIP Error - Status: 0x{:02X}, Message: {}", general_status, error_msg);
-            return Err(EtherNetIpError::Protocol(format!("CIP Error {}: {}", general_status, error_msg)));
+            println!(
+                "🔧 [DEBUG] CIP Error - Status: 0x{:02X}, Message: {}",
+                general_status, error_msg
+            );
+            return Err(EtherNetIpError::Protocol(format!(
+                "CIP Error {}: {}",
+                general_status, error_msg
+            )));
         }
 
         // For read operations, parse the returned data
-        if service_reply == 0xCC { // Read Tag reply
+        if service_reply == 0xCC {
+            // Read Tag reply
             if cip_response.len() < 6 {
-                return Err(EtherNetIpError::Protocol("Read response too short for data".to_string()));
+                return Err(EtherNetIpError::Protocol(
+                    "Read response too short for data".to_string(),
+                ));
             }
-            
+
             let data_type = u16::from_le_bytes([cip_response[4], cip_response[5]]);
             let value_data = &cip_response[6..];
-            
-            println!("🔧 [DEBUG] Data type: 0x{:04X}, Value data ({} bytes): {:02X?}", 
-                     data_type, value_data.len(), value_data);
-            
+
+            println!(
+                "🔧 [DEBUG] Data type: 0x{:04X}, Value data ({} bytes): {:02X?}",
+                data_type,
+                value_data.len(),
+                value_data
+            );
+
             // Parse based on data type
             match data_type {
-                0x00C1 => { // BOOL
+                0x00C1 => {
+                    // BOOL
                     if value_data.is_empty() {
-                        return Err(EtherNetIpError::Protocol("No data for BOOL value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "No data for BOOL value".to_string(),
+                        ));
                     }
                     let value = value_data[0] != 0;
                     println!("🔧 [DEBUG] Parsed BOOL: {}", value);
                     Ok(PlcValue::Bool(value))
                 }
-                0x00C2 => { // SINT
+                0x00C2 => {
+                    // SINT
                     if value_data.is_empty() {
-                        return Err(EtherNetIpError::Protocol("No data for SINT value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "No data for SINT value".to_string(),
+                        ));
                     }
                     let value = value_data[0] as i8;
                     println!("🔧 [DEBUG] Parsed SINT: {}", value);
                     Ok(PlcValue::Sint(value))
                 }
-                0x00C3 => { // INT
+                0x00C3 => {
+                    // INT
                     if value_data.len() < 2 {
-                        return Err(EtherNetIpError::Protocol("Insufficient data for INT value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "Insufficient data for INT value".to_string(),
+                        ));
                     }
                     let value = i16::from_le_bytes([value_data[0], value_data[1]]);
                     println!("🔧 [DEBUG] Parsed INT: {}", value);
                     Ok(PlcValue::Int(value))
                 }
-                0x00C4 => { // DINT
+                0x00C4 => {
+                    // DINT
                     if value_data.len() < 4 {
-                        return Err(EtherNetIpError::Protocol("Insufficient data for DINT value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "Insufficient data for DINT value".to_string(),
+                        ));
                     }
                     let value = i32::from_le_bytes([
-                        value_data[0], value_data[1], 
-                        value_data[2], value_data[3]
+                        value_data[0],
+                        value_data[1],
+                        value_data[2],
+                        value_data[3],
                     ]);
                     println!("🔧 [DEBUG] Parsed DINT: {}", value);
                     Ok(PlcValue::Dint(value))
                 }
-                0x00CA => { // REAL
+                0x00CA => {
+                    // REAL
                     if value_data.len() < 4 {
-                        return Err(EtherNetIpError::Protocol("Insufficient data for REAL value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "Insufficient data for REAL value".to_string(),
+                        ));
                     }
                     let value = f32::from_le_bytes([
-                        value_data[0], value_data[1],
-                        value_data[2], value_data[3]
+                        value_data[0],
+                        value_data[1],
+                        value_data[2],
+                        value_data[3],
                     ]);
                     println!("🔧 [DEBUG] Parsed REAL: {}", value);
                     Ok(PlcValue::Real(value))
                 }
-                0x00DA => { // STRING
+                0x00DA => {
+                    // STRING
                     if value_data.is_empty() {
                         return Ok(PlcValue::String(String::new()));
                     }
                     let length = value_data[0] as usize;
                     if value_data.len() < 1 + length {
-                        return Err(EtherNetIpError::Protocol("Insufficient data for STRING value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "Insufficient data for STRING value".to_string(),
+                        ));
                     }
                     let string_data = &value_data[1..1 + length];
                     let value = String::from_utf8_lossy(string_data).to_string();
                     println!("🔧 [DEBUG] Parsed STRING: '{}'", value);
                     Ok(PlcValue::String(value))
                 }
-                0x02A0 => { // Alternative STRING type (Allen-Bradley specific)
+                0x02A0 => {
+                    // Alternative STRING type (Allen-Bradley specific)
                     if value_data.len() < 7 {
-                        return Err(EtherNetIpError::Protocol("Insufficient data for alternative STRING value".to_string()));
+                        return Err(EtherNetIpError::Protocol(
+                            "Insufficient data for alternative STRING value".to_string(),
+                        ));
                     }
-                    
+
                     // For this format, the string data starts directly at position 6
                     // We need to find the null terminator or use the full remaining length
                     let string_start = 6;
                     let string_data = &value_data[string_start..];
-                    
+
                     // Find null terminator or use full length
-                    let string_end = string_data.iter().position(|&b| b == 0).unwrap_or(string_data.len());
+                    let string_end = string_data
+                        .iter()
+                        .position(|&b| b == 0)
+                        .unwrap_or(string_data.len());
                     let string_bytes = &string_data[..string_end];
-                    
+
                     let value = String::from_utf8_lossy(string_bytes).to_string();
                     println!("🔧 [DEBUG] Parsed alternative STRING (0x02A0): '{}'", value);
                     Ok(PlcValue::String(value))
                 }
                 _ => {
                     println!("🔧 [DEBUG] Unknown data type: 0x{:04X}", data_type);
-                    Err(EtherNetIpError::Protocol(format!("Unsupported data type: 0x{:04X}", data_type)))
+                    Err(EtherNetIpError::Protocol(format!(
+                        "Unsupported data type: 0x{:04X}",
+                        data_type
+                    )))
                 }
             }
-        } else if service_reply == 0xCD { // Write Tag reply - no data to parse
+        } else if service_reply == 0xCD {
+            // Write Tag reply - no data to parse
             println!("🔧 [DEBUG] Write operation successful");
             Ok(PlcValue::Bool(true)) // Indicate success
         } else {
-            Err(EtherNetIpError::Protocol(format!("Unknown service reply: 0x{:02X}", service_reply)))
+            Err(EtherNetIpError::Protocol(format!(
+                "Unknown service reply: 0x{:02X}",
+                service_reply
+            )))
         }
     }
 
     /// Unregisters the EtherNet/IP session with the PLC
     pub async fn unregister_session(&mut self) -> crate::error::Result<()> {
         println!("🔌 Unregistering session and cleaning up connections...");
-        
+
         // Close all connected sessions first
         let _ = self.close_all_connected_sessions().await;
-        
+
         let mut packet = Vec::new();
-        
+
         // EtherNet/IP header
         packet.extend_from_slice(&[0x66, 0x00]); // Command: Unregister Session
         packet.extend_from_slice(&[0x04, 0x00]); // Length: 4 bytes
@@ -1808,12 +1989,17 @@ impl EipClient {
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Status
         packet.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]); // Sender context
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Options
-        
+
         // Protocol version for unregister session
         packet.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]); // Protocol version 1
-        
-        self.stream.lock().await.write_all(&packet).await.map_err(EtherNetIpError::Io)?;
-        
+
+        self.stream
+            .lock()
+            .await
+            .write_all(&packet)
+            .await
+            .map_err(EtherNetIpError::Io)?;
+
         println!("✅ Session unregistered and all connections closed");
         Ok(())
     }
@@ -1821,39 +2007,42 @@ impl EipClient {
     /// Builds a CIP Read Tag Service request
     fn build_read_request(&self, tag_name: &str) -> Vec<u8> {
         println!("🔧 [DEBUG] Building read request for tag: '{}'", tag_name);
-        
+
         // Use Connected Explicit Messaging for better compatibility
         // This is simpler and more widely supported across different PLC types
         let mut cip_request = Vec::new();
-        
+
         // Service: Read Tag Service (0x4C)
         cip_request.push(0x4C);
-        
+
         // Request Path Size (in words)
         let tag_bytes = tag_name.as_bytes();
-        let path_len = if tag_bytes.len() % 2 == 0 { 
-            tag_bytes.len() + 2 
-        } else { 
-            tag_bytes.len() + 3 
+        let path_len = if tag_bytes.len() % 2 == 0 {
+            tag_bytes.len() + 2
+        } else {
+            tag_bytes.len() + 3
         };
         cip_request.push((path_len / 2) as u8);
-        
+
         // Request Path: ANSI Extended Symbol Segment for tag name
         cip_request.push(0x91); // ANSI Extended Symbol Segment
         cip_request.push(tag_bytes.len() as u8); // Tag name length
         cip_request.extend_from_slice(tag_bytes); // Tag name
-        
+
         // Pad to even length if necessary
         if tag_bytes.len() % 2 != 0 {
             cip_request.push(0x00);
         }
-        
+
         // Element count (little-endian)
         cip_request.extend_from_slice(&[0x01, 0x00]); // Read 1 element
-        
-        println!("🔧 [DEBUG] Built CIP read request ({} bytes): {:02X?}", 
-                 cip_request.len(), cip_request);
-        
+
+        println!(
+            "🔧 [DEBUG] Built CIP read request ({} bytes): {:02X?}",
+            cip_request.len(),
+            cip_request
+        );
+
         cip_request
     }
 
@@ -1862,46 +2051,46 @@ impl EipClient {
     // =========================================================================
 
     /// Executes a batch of read and write operations
-    /// 
+    ///
     /// This is the main entry point for batch operations. It takes a slice of
     /// `BatchOperation` items and executes them efficiently by grouping them
     /// into optimal CIP packets based on the current `BatchConfig`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `operations` - A slice of operations to execute
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A vector of `BatchResult` items, one for each input operation.
     /// Results are returned in the same order as the input operations.
-    /// 
+    ///
     /// # Performance
-    /// 
+    ///
     /// - **Throughput**: 5,000-15,000+ operations/second (vs 1,500 individual)
     /// - **Latency**: 5-20ms per batch (vs 1-3ms per individual operation)
     /// - **Network efficiency**: 1-5 packets vs N packets for N operations
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,no_run
     /// use rust_ethernet_ip::{EipClient, BatchOperation, PlcValue};
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-    ///     
+    ///
     ///     let operations = vec![
     ///         BatchOperation::Read { tag_name: "Motor1_Speed".to_string() },
     ///         BatchOperation::Read { tag_name: "Motor2_Speed".to_string() },
-    ///         BatchOperation::Write { 
-    ///             tag_name: "SetPoint".to_string(), 
-    ///             value: PlcValue::Dint(1500) 
+    ///         BatchOperation::Write {
+    ///             tag_name: "SetPoint".to_string(),
+    ///             value: PlcValue::Dint(1500)
     ///         },
     ///     ];
-    ///     
+    ///
     ///     let results = client.execute_batch(&operations).await?;
-    ///     
+    ///
     ///     for result in results {
     ///         match result.result {
     ///             Ok(Some(value)) => println!("Read value: {:?}", value),
@@ -1909,17 +2098,23 @@ impl EipClient {
     ///             Err(e) => println!("Operation failed: {}", e),
     ///         }
     ///     }
-    ///     
+    ///
     ///     Ok(())
     /// }
     /// ```
-    pub async fn execute_batch(&mut self, operations: &[BatchOperation]) -> crate::error::Result<Vec<BatchResult>> {
+    pub async fn execute_batch(
+        &mut self,
+        operations: &[BatchOperation],
+    ) -> crate::error::Result<Vec<BatchResult>> {
         if operations.is_empty() {
             return Ok(Vec::new());
         }
 
         let start_time = Instant::now();
-        println!("🚀 [BATCH] Starting batch execution with {} operations", operations.len());
+        println!(
+            "🚀 [BATCH] Starting batch execution with {} operations",
+            operations.len()
+        );
 
         // Group operations based on configuration
         let operation_groups = if self.batch_config.optimize_packet_packing {
@@ -1932,8 +2127,12 @@ impl EipClient {
 
         // Execute each group
         for (group_index, group) in operation_groups.iter().enumerate() {
-            println!("🔧 [BATCH] Processing group {} with {} operations", group_index + 1, group.len());
-            
+            println!(
+                "🔧 [BATCH] Processing group {} with {} operations",
+                group_index + 1,
+                group.len()
+            );
+
             match self.execute_operation_group(group).await {
                 Ok(mut group_results) => {
                     all_results.append(&mut group_results);
@@ -1942,7 +2141,7 @@ impl EipClient {
                     if !self.batch_config.continue_on_error {
                         return Err(e);
                     }
-                    
+
                     // Create error results for this group
                     for op in group {
                         let error_result = BatchResult {
@@ -1957,156 +2156,177 @@ impl EipClient {
         }
 
         let total_time = start_time.elapsed();
-        println!("✅ [BATCH] Completed batch execution in {:?} - {} operations processed", 
-                 total_time, all_results.len());
+        println!(
+            "✅ [BATCH] Completed batch execution in {:?} - {} operations processed",
+            total_time,
+            all_results.len()
+        );
 
         Ok(all_results)
     }
 
     /// Reads multiple tags in a single batch operation
-    /// 
+    ///
     /// This is a convenience method for read-only batch operations.
     /// It's optimized for reading many tags at once.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_names` - A slice of tag names to read
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A vector of tuples containing (tag_name, result) pairs
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,no_run
     /// use rust_ethernet_ip::EipClient;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-    ///     
+    ///
     ///     let tags = ["Motor1_Speed", "Motor2_Speed", "Temperature", "Pressure"];
     ///     let results = client.read_tags_batch(&tags).await?;
-    ///     
+    ///
     ///     for (tag_name, result) in results {
     ///         match result {
     ///             Ok(value) => println!("{}: {:?}", tag_name, value),
     ///             Err(e) => println!("{}: Error - {}", tag_name, e),
     ///         }
     ///     }
-    ///     
+    ///
     ///     Ok(())
     /// }
     /// ```
-    pub async fn read_tags_batch(&mut self, tag_names: &[&str]) -> crate::error::Result<Vec<(String, std::result::Result<PlcValue, BatchError>)>> {
+    pub async fn read_tags_batch(
+        &mut self,
+        tag_names: &[&str],
+    ) -> crate::error::Result<Vec<(String, std::result::Result<PlcValue, BatchError>)>> {
         let operations: Vec<BatchOperation> = tag_names
             .iter()
-            .map(|&name| BatchOperation::Read { tag_name: name.to_string() })
+            .map(|&name| BatchOperation::Read {
+                tag_name: name.to_string(),
+            })
             .collect();
 
         let results = self.execute_batch(&operations).await?;
-        
-        Ok(results.into_iter().map(|result| {
-            let tag_name = match &result.operation {
-                BatchOperation::Read { tag_name } => tag_name.clone(),
-                _ => unreachable!("Should only have read operations"),
-            };
-            
-            let value_result = match result.result {
-                Ok(Some(value)) => Ok(value),
-                Ok(None) => Err(BatchError::Other("Unexpected None result for read operation".to_string())),
-                Err(e) => Err(e),
-            };
-            
-            (tag_name, value_result)
-        }).collect())
+
+        Ok(results
+            .into_iter()
+            .map(|result| {
+                let tag_name = match &result.operation {
+                    BatchOperation::Read { tag_name } => tag_name.clone(),
+                    _ => unreachable!("Should only have read operations"),
+                };
+
+                let value_result = match result.result {
+                    Ok(Some(value)) => Ok(value),
+                    Ok(None) => Err(BatchError::Other(
+                        "Unexpected None result for read operation".to_string(),
+                    )),
+                    Err(e) => Err(e),
+                };
+
+                (tag_name, value_result)
+            })
+            .collect())
     }
 
     /// Writes multiple tag values in a single batch operation
-    /// 
+    ///
     /// This is a convenience method for write-only batch operations.
     /// It's optimized for writing many values at once.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_values` - A slice of (tag_name, value) tuples to write
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// A vector of tuples containing (tag_name, result) pairs
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,no_run
     /// use rust_ethernet_ip::{EipClient, PlcValue};
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-    ///     
+    ///
     ///     let writes = vec![
     ///         ("SetPoint1", PlcValue::Bool(true)),
     ///         ("SetPoint2", PlcValue::Dint(2000)),
     ///         ("EnableFlag", PlcValue::Bool(true)),
     ///     ];
-    ///     
+    ///
     ///     let results = client.write_tags_batch(&writes).await?;
-    ///     
+    ///
     ///     for (tag_name, result) in results {
     ///         match result {
     ///             Ok(_) => println!("{}: Write successful", tag_name),
     ///             Err(e) => println!("{}: Write failed - {}", tag_name, e),
     ///         }
     ///     }
-    ///     
+    ///
     ///     Ok(())
     /// }
     /// ```
-    pub async fn write_tags_batch(&mut self, tag_values: &[(&str, PlcValue)]) -> crate::error::Result<Vec<(String, std::result::Result<(), BatchError>)>> {
+    pub async fn write_tags_batch(
+        &mut self,
+        tag_values: &[(&str, PlcValue)],
+    ) -> crate::error::Result<Vec<(String, std::result::Result<(), BatchError>)>> {
         let operations: Vec<BatchOperation> = tag_values
             .iter()
-            .map(|(name, value)| BatchOperation::Write { 
-                tag_name: name.to_string(), 
-                value: value.clone() 
+            .map(|(name, value)| BatchOperation::Write {
+                tag_name: name.to_string(),
+                value: value.clone(),
             })
             .collect();
 
         let results = self.execute_batch(&operations).await?;
-        
-        Ok(results.into_iter().map(|result| {
-            let tag_name = match &result.operation {
-                BatchOperation::Write { tag_name, .. } => tag_name.clone(),
-                _ => unreachable!("Should only have write operations"),
-            };
-            
-            let write_result = match result.result {
-                Ok(None) => Ok(()),
-                Ok(Some(_)) => Err(BatchError::Other("Unexpected value result for write operation".to_string())),
-                Err(e) => Err(e),
-            };
-            
-            (tag_name, write_result)
-        }).collect())
+
+        Ok(results
+            .into_iter()
+            .map(|result| {
+                let tag_name = match &result.operation {
+                    BatchOperation::Write { tag_name, .. } => tag_name.clone(),
+                    _ => unreachable!("Should only have write operations"),
+                };
+
+                let write_result = match result.result {
+                    Ok(None) => Ok(()),
+                    Ok(Some(_)) => Err(BatchError::Other(
+                        "Unexpected value result for write operation".to_string(),
+                    )),
+                    Err(e) => Err(e),
+                };
+
+                (tag_name, write_result)
+            })
+            .collect())
     }
 
     /// Configures batch operation settings
-    /// 
+    ///
     /// This method allows fine-tuning of batch operation behavior,
     /// including performance optimizations and error handling.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `config` - The new batch configuration to use
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,no_run
     /// use rust_ethernet_ip::{EipClient, BatchConfig};
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     ///     let mut client = EipClient::connect("192.168.1.100:44818").await?;
-    ///     
+    ///
     ///     let config = BatchConfig {
     ///         max_operations_per_packet: 50,
     ///         max_packet_size: 1500,
@@ -2114,18 +2334,20 @@ impl EipClient {
     ///         continue_on_error: false,
     ///         optimize_packet_packing: true,
     ///     };
-    ///     
+    ///
     ///     client.configure_batch_operations(config);
-    ///     
+    ///
     ///     Ok(())
     /// }
     /// ```
     pub fn configure_batch_operations(&mut self, config: BatchConfig) {
         self.batch_config = config;
-        println!("🔧 [BATCH] Updated batch configuration: max_ops={}, max_size={}, timeout={}ms", 
-                 self.batch_config.max_operations_per_packet,
-                 self.batch_config.max_packet_size,
-                 self.batch_config.packet_timeout_ms);
+        println!(
+            "🔧 [BATCH] Updated batch configuration: max_ops={}, max_size={}, timeout={}ms",
+            self.batch_config.max_operations_per_packet,
+            self.batch_config.max_packet_size,
+            self.batch_config.packet_timeout_ms
+        );
     }
 
     /// Gets current batch operation configuration
@@ -2165,7 +2387,10 @@ impl EipClient {
     }
 
     /// Groups operations sequentially (preserves order)
-    fn sequential_operation_groups(&self, operations: &[BatchOperation]) -> Vec<Vec<BatchOperation>> {
+    fn sequential_operation_groups(
+        &self,
+        operations: &[BatchOperation],
+    ) -> Vec<Vec<BatchOperation>> {
         operations
             .chunks(self.batch_config.max_operations_per_packet)
             .map(|chunk| chunk.to_vec())
@@ -2173,34 +2398,39 @@ impl EipClient {
     }
 
     /// Executes a single group of operations as a CIP Multiple Service Packet
-    async fn execute_operation_group(&mut self, operations: &[BatchOperation]) -> crate::error::Result<Vec<BatchResult>> {
+    async fn execute_operation_group(
+        &mut self,
+        operations: &[BatchOperation],
+    ) -> crate::error::Result<Vec<BatchResult>> {
         let start_time = Instant::now();
         let mut results = Vec::with_capacity(operations.len());
 
         // Build Multiple Service Packet request
         let cip_request = self.build_multiple_service_packet(operations)?;
-        
+
         // Send request and get response
         let response = self.send_cip_request(&cip_request).await?;
-        
+
         // Parse response and create results
         let parsed_results = self.parse_multiple_service_response(&response, operations)?;
-        
+
         let execution_time = start_time.elapsed();
-        
+
         // Create BatchResult objects
         for (i, operation) in operations.iter().enumerate() {
             let op_execution_time = execution_time.as_micros() as u64 / operations.len() as u64;
-            
+
             let result = if i < parsed_results.len() {
                 match &parsed_results[i] {
                     Ok(value) => Ok(value.clone()),
                     Err(e) => Err(e.clone()),
                 }
             } else {
-                Err(BatchError::Other("Missing result from response".to_string()))
+                Err(BatchError::Other(
+                    "Missing result from response".to_string(),
+                ))
             };
-            
+
             results.push(BatchResult {
                 operation: operation.clone(),
                 result,
@@ -2212,8 +2442,11 @@ impl EipClient {
     }
 
     /// Builds a CIP Multiple Service Packet request
-    fn build_multiple_service_packet(&self, operations: &[BatchOperation]) -> crate::error::Result<Vec<u8>> {
-        let mut packet = Vec::new();
+    fn build_multiple_service_packet(
+        &self,
+        operations: &[BatchOperation],
+    ) -> crate::error::Result<Vec<u8>> {
+        let mut packet = Vec::with_capacity(8 + (operations.len() * 2));
 
         // Multiple Service Packet service code
         packet.push(0x0A);
@@ -2222,22 +2455,20 @@ impl EipClient {
         packet.push(0x02); // Path size in words
         packet.push(0x20); // Class segment
         packet.push(0x02); // Class 0x02 (Message Router)
-        packet.push(0x24); // Instance segment  
+        packet.push(0x24); // Instance segment
         packet.push(0x01); // Instance 1
 
         // Number of services
         packet.extend_from_slice(&(operations.len() as u16).to_le_bytes());
 
         // Calculate offset table
-        let mut service_requests = Vec::new();
+        let mut service_requests = Vec::with_capacity(operations.len());
         let mut current_offset = 2 + (operations.len() * 2); // Start after offset table
 
         for operation in operations {
             // Build individual service request
             let service_request = match operation {
-                BatchOperation::Read { tag_name } => {
-                    self.build_read_request(tag_name)
-                }
+                BatchOperation::Read { tag_name } => self.build_read_request(tag_name),
                 BatchOperation::Write { tag_name, value } => {
                     self.build_write_request(tag_name, value)?
                 }
@@ -2257,21 +2488,34 @@ impl EipClient {
             packet.extend_from_slice(&service_request);
         }
 
-        println!("🔧 [BATCH] Built Multiple Service Packet ({} bytes, {} services)", 
-                 packet.len(), operations.len());
+        println!(
+            "🔧 [BATCH] Built Multiple Service Packet ({} bytes, {} services)",
+            packet.len(),
+            operations.len()
+        );
 
         Ok(packet)
     }
 
     /// Parses a Multiple Service Packet response
-    fn parse_multiple_service_response(&self, response: &[u8], operations: &[BatchOperation]) -> crate::error::Result<Vec<std::result::Result<Option<PlcValue>, BatchError>>> {
+    fn parse_multiple_service_response(
+        &self,
+        response: &[u8],
+        operations: &[BatchOperation],
+    ) -> crate::error::Result<Vec<std::result::Result<Option<PlcValue>, BatchError>>> {
         if response.len() < 6 {
-            return Err(crate::error::EtherNetIpError::Protocol("Response too short for Multiple Service Packet".to_string()));
+            return Err(crate::error::EtherNetIpError::Protocol(
+                "Response too short for Multiple Service Packet".to_string(),
+            ));
         }
 
         let mut results = Vec::new();
 
-        println!("🔧 [DEBUG] Raw Multiple Service Response ({} bytes): {:02X?}", response.len(), response);
+        println!(
+            "🔧 [DEBUG] Raw Multiple Service Response ({} bytes): {:02X?}",
+            response.len(),
+            response
+        );
 
         // First, extract the CIP data from the EtherNet/IP response
         let cip_data = match self.extract_cip_from_response(response) {
@@ -2282,43 +2526,61 @@ impl EipClient {
             }
         };
 
-        println!("🔧 [DEBUG] Extracted CIP data ({} bytes): {:02X?}", cip_data.len(), cip_data);
+        println!(
+            "🔧 [DEBUG] Extracted CIP data ({} bytes): {:02X?}",
+            cip_data.len(),
+            cip_data
+        );
 
         if cip_data.len() < 6 {
-            return Err(crate::error::EtherNetIpError::Protocol("CIP data too short for Multiple Service Response".to_string()));
+            return Err(crate::error::EtherNetIpError::Protocol(
+                "CIP data too short for Multiple Service Response".to_string(),
+            ));
         }
 
         // Parse Multiple Service Response header from CIP data:
         // [0] = Service Code (0x8A)
-        // [1] = Reserved (0x00)  
+        // [1] = Reserved (0x00)
         // [2] = General Status (0x00 for success)
         // [3] = Additional Status Size (0x00)
         // [4-5] = Number of replies (little endian)
-        
+
         let service_code = cip_data[0];
         let general_status = cip_data[2];
         let num_replies = u16::from_le_bytes([cip_data[4], cip_data[5]]) as usize;
 
-        println!("🔧 [DEBUG] Multiple Service Response: service=0x{:02X}, status=0x{:02X}, replies={}", 
-                service_code, general_status, num_replies);
+        println!(
+            "🔧 [DEBUG] Multiple Service Response: service=0x{:02X}, status=0x{:02X}, replies={}",
+            service_code, general_status, num_replies
+        );
 
         if general_status != 0x00 {
-            return Err(crate::error::EtherNetIpError::Protocol(format!("Multiple Service Response error: 0x{:02X}", general_status)));
+            return Err(crate::error::EtherNetIpError::Protocol(format!(
+                "Multiple Service Response error: 0x{:02X}",
+                general_status
+            )));
         }
 
         if num_replies != operations.len() {
-            return Err(crate::error::EtherNetIpError::Protocol(format!("Reply count mismatch: expected {}, got {}", operations.len(), num_replies)));
+            return Err(crate::error::EtherNetIpError::Protocol(format!(
+                "Reply count mismatch: expected {}, got {}",
+                operations.len(),
+                num_replies
+            )));
         }
 
         // Read reply offsets (each is 2 bytes, little endian)
         let mut reply_offsets = Vec::new();
         let mut offset = 6; // Skip header
-        
+
         for _i in 0..num_replies {
             if offset + 2 > cip_data.len() {
-                return Err(crate::error::EtherNetIpError::Protocol("CIP data too short for reply offsets".to_string()));
+                return Err(crate::error::EtherNetIpError::Protocol(
+                    "CIP data too short for reply offsets".to_string(),
+                ));
             }
-            let reply_offset = u16::from_le_bytes([cip_data[offset], cip_data[offset + 1]]) as usize;
+            let reply_offset =
+                u16::from_le_bytes([cip_data[offset], cip_data[offset + 1]]) as usize;
             reply_offsets.push(reply_offset);
             offset += 2;
         }
@@ -2327,16 +2589,18 @@ impl EipClient {
 
         // The reply data starts after all the offsets
         let reply_base_offset = 6 + (num_replies * 2);
-        
+
         println!("🔧 [DEBUG] Reply base offset: {}", reply_base_offset);
 
         // Parse each reply
         for (i, &reply_offset) in reply_offsets.iter().enumerate() {
             // Reply offset is relative to position 4 (after service code, reserved, status, additional status size)
             let reply_start = 4 + reply_offset;
-            
+
             if reply_start >= cip_data.len() {
-                results.push(Err(BatchError::Other("Reply offset beyond CIP data".to_string())));
+                results.push(Err(BatchError::Other(
+                    "Reply offset beyond CIP data".to_string(),
+                )));
                 continue;
             }
 
@@ -2350,14 +2614,22 @@ impl EipClient {
             };
 
             if reply_end > cip_data.len() || reply_start >= reply_end {
-                results.push(Err(BatchError::Other("Invalid reply boundaries".to_string())));
+                results.push(Err(BatchError::Other(
+                    "Invalid reply boundaries".to_string(),
+                )));
                 continue;
             }
 
             let reply_data = &cip_data[reply_start..reply_end];
-            
-            println!("🔧 [DEBUG] Reply {} at offset {}: start={}, end={}, len={}", 
-                    i, reply_offset, reply_start, reply_end, reply_data.len());
+
+            println!(
+                "🔧 [DEBUG] Reply {} at offset {}: start={}, end={}, len={}",
+                i,
+                reply_offset,
+                reply_start,
+                reply_end,
+                reply_data.len()
+            );
             println!("🔧 [DEBUG] Reply {} data: {:02X?}", i, reply_data);
 
             let result = self.parse_individual_reply(reply_data, &operations[i]);
@@ -2368,12 +2640,22 @@ impl EipClient {
     }
 
     /// Parses an individual service reply within a Multiple Service Packet response
-    fn parse_individual_reply(&self, reply_data: &[u8], operation: &BatchOperation) -> std::result::Result<Option<PlcValue>, BatchError> {
+    fn parse_individual_reply(
+        &self,
+        reply_data: &[u8],
+        operation: &BatchOperation,
+    ) -> std::result::Result<Option<PlcValue>, BatchError> {
         if reply_data.len() < 4 {
-            return Err(BatchError::SerializationError("Reply too short".to_string()));
+            return Err(BatchError::SerializationError(
+                "Reply too short".to_string(),
+            ));
         }
 
-        println!("🔧 [DEBUG] Parsing individual reply ({} bytes): {:02X?}", reply_data.len(), reply_data);
+        println!(
+            "🔧 [DEBUG] Parsing individual reply ({} bytes): {:02X?}",
+            reply_data.len(),
+            reply_data
+        );
 
         // Each individual reply in Multiple Service Response has the same format as standalone CIP response:
         // [0] = Service Code (0xCC for read response, 0xCD for write response)
@@ -2385,13 +2667,16 @@ impl EipClient {
         let service_code = reply_data[0];
         let general_status = reply_data[2];
 
-        println!("🔧 [DEBUG] Service code: 0x{:02X}, Status: 0x{:02X}", service_code, general_status);
+        println!(
+            "🔧 [DEBUG] Service code: 0x{:02X}, Status: 0x{:02X}",
+            service_code, general_status
+        );
 
         if general_status != 0x00 {
             let error_msg = self.get_cip_error_message(general_status);
-            return Err(BatchError::CipError { 
-                status: general_status, 
-                message: error_msg 
+            return Err(BatchError::CipError {
+                status: general_status,
+                message: error_msg,
             });
         }
 
@@ -2403,43 +2688,62 @@ impl EipClient {
             BatchOperation::Read { .. } => {
                 // Read operations return data starting at offset 4
                 if reply_data.len() < 6 {
-                    return Err(BatchError::SerializationError("Read reply too short for data".to_string()));
+                    return Err(BatchError::SerializationError(
+                        "Read reply too short for data".to_string(),
+                    ));
                 }
 
                 // Parse the data directly (skip the 4-byte header)
                 // Data format: [type_low, type_high, value_bytes...]
                 let data = &reply_data[4..];
-                println!("🔧 [DEBUG] Parsing data ({} bytes): {:02X?}", data.len(), data);
-                
+                println!(
+                    "🔧 [DEBUG] Parsing data ({} bytes): {:02X?}",
+                    data.len(),
+                    data
+                );
+
                 if data.len() < 2 {
-                    return Err(BatchError::SerializationError("Data too short for type".to_string()));
+                    return Err(BatchError::SerializationError(
+                        "Data too short for type".to_string(),
+                    ));
                 }
 
                 let data_type = u16::from_le_bytes([data[0], data[1]]);
                 let value_data = &data[2..];
-                
-                println!("🔧 [DEBUG] Data type: 0x{:04X}, Value data ({} bytes): {:02X?}", data_type, value_data.len(), value_data);
+
+                println!(
+                    "🔧 [DEBUG] Data type: 0x{:04X}, Value data ({} bytes): {:02X?}",
+                    data_type,
+                    value_data.len(),
+                    value_data
+                );
 
                 // Parse based on data type
                 match data_type {
                     0x00C1 => {
                         // BOOL
                         if value_data.is_empty() {
-                            return Err(BatchError::SerializationError("Missing BOOL value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing BOOL value".to_string(),
+                            ));
                         }
                         Ok(Some(PlcValue::Bool(value_data[0] != 0)))
                     }
                     0x00C2 => {
                         // SINT
                         if value_data.is_empty() {
-                            return Err(BatchError::SerializationError("Missing SINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing SINT value".to_string(),
+                            ));
                         }
                         Ok(Some(PlcValue::Sint(value_data[0] as i8)))
                     }
                     0x00C3 => {
                         // INT
                         if value_data.len() < 2 {
-                            return Err(BatchError::SerializationError("Missing INT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing INT value".to_string(),
+                            ));
                         }
                         let value = i16::from_le_bytes([value_data[0], value_data[1]]);
                         Ok(Some(PlcValue::Int(value)))
@@ -2447,34 +2751,53 @@ impl EipClient {
                     0x00C4 => {
                         // DINT
                         if value_data.len() < 4 {
-                            return Err(BatchError::SerializationError("Missing DINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing DINT value".to_string(),
+                            ));
                         }
-                        let value = i32::from_le_bytes([value_data[0], value_data[1], value_data[2], value_data[3]]);
+                        let value = i32::from_le_bytes([
+                            value_data[0],
+                            value_data[1],
+                            value_data[2],
+                            value_data[3],
+                        ]);
                         println!("🔧 [DEBUG] Parsed DINT: {}", value);
                         Ok(Some(PlcValue::Dint(value)))
                     }
                     0x00C5 => {
                         // LINT
                         if value_data.len() < 8 {
-                            return Err(BatchError::SerializationError("Missing LINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing LINT value".to_string(),
+                            ));
                         }
                         let value = i64::from_le_bytes([
-                            value_data[0], value_data[1], value_data[2], value_data[3],
-                            value_data[4], value_data[5], value_data[6], value_data[7]
+                            value_data[0],
+                            value_data[1],
+                            value_data[2],
+                            value_data[3],
+                            value_data[4],
+                            value_data[5],
+                            value_data[6],
+                            value_data[7],
                         ]);
                         Ok(Some(PlcValue::Lint(value)))
                     }
                     0x00C6 => {
                         // USINT
                         if value_data.is_empty() {
-                            return Err(BatchError::SerializationError("Missing USINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing USINT value".to_string(),
+                            ));
                         }
                         Ok(Some(PlcValue::Usint(value_data[0])))
                     }
                     0x00C7 => {
                         // UINT
                         if value_data.len() < 2 {
-                            return Err(BatchError::SerializationError("Missing UINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing UINT value".to_string(),
+                            ));
                         }
                         let value = u16::from_le_bytes([value_data[0], value_data[1]]);
                         Ok(Some(PlcValue::Uint(value)))
@@ -2482,26 +2805,43 @@ impl EipClient {
                     0x00C8 => {
                         // UDINT
                         if value_data.len() < 4 {
-                            return Err(BatchError::SerializationError("Missing UDINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing UDINT value".to_string(),
+                            ));
                         }
-                        let value = u32::from_le_bytes([value_data[0], value_data[1], value_data[2], value_data[3]]);
+                        let value = u32::from_le_bytes([
+                            value_data[0],
+                            value_data[1],
+                            value_data[2],
+                            value_data[3],
+                        ]);
                         Ok(Some(PlcValue::Udint(value)))
                     }
                     0x00C9 => {
                         // ULINT
                         if value_data.len() < 8 {
-                            return Err(BatchError::SerializationError("Missing ULINT value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing ULINT value".to_string(),
+                            ));
                         }
                         let value = u64::from_le_bytes([
-                            value_data[0], value_data[1], value_data[2], value_data[3],
-                            value_data[4], value_data[5], value_data[6], value_data[7]
+                            value_data[0],
+                            value_data[1],
+                            value_data[2],
+                            value_data[3],
+                            value_data[4],
+                            value_data[5],
+                            value_data[6],
+                            value_data[7],
                         ]);
                         Ok(Some(PlcValue::Ulint(value)))
                     }
                     0x00CA => {
                         // REAL
                         if value_data.len() < 4 {
-                            return Err(BatchError::SerializationError("Missing REAL value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing REAL value".to_string(),
+                            ));
                         }
                         let bytes = [value_data[0], value_data[1], value_data[2], value_data[3]];
                         let value = f32::from_le_bytes(bytes);
@@ -2511,11 +2851,19 @@ impl EipClient {
                     0x00CB => {
                         // LREAL
                         if value_data.len() < 8 {
-                            return Err(BatchError::SerializationError("Missing LREAL value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Missing LREAL value".to_string(),
+                            ));
                         }
                         let bytes = [
-                            value_data[0], value_data[1], value_data[2], value_data[3],
-                            value_data[4], value_data[5], value_data[6], value_data[7]
+                            value_data[0],
+                            value_data[1],
+                            value_data[2],
+                            value_data[3],
+                            value_data[4],
+                            value_data[5],
+                            value_data[6],
+                            value_data[7],
                         ];
                         let value = f64::from_le_bytes(bytes);
                         Ok(Some(PlcValue::Lreal(value)))
@@ -2527,7 +2875,9 @@ impl EipClient {
                         }
                         let length = value_data[0] as usize;
                         if value_data.len() < 1 + length {
-                            return Err(BatchError::SerializationError("Insufficient data for STRING value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Insufficient data for STRING value".to_string(),
+                            ));
                         }
                         let string_data = &value_data[1..1 + length];
                         let value = String::from_utf8_lossy(string_data).to_string();
@@ -2537,25 +2887,31 @@ impl EipClient {
                     0x02A0 => {
                         // Alternative STRING type (Allen-Bradley specific) for batch operations
                         if value_data.len() < 7 {
-                            return Err(BatchError::SerializationError("Insufficient data for alternative STRING value".to_string()));
+                            return Err(BatchError::SerializationError(
+                                "Insufficient data for alternative STRING value".to_string(),
+                            ));
                         }
-                        
+
                         // For this format, the string data starts directly at position 6
                         // We need to find the null terminator or use the full remaining length
                         let string_start = 6;
                         let string_data = &value_data[string_start..];
-                        
+
                         // Find null terminator or use full length
-                        let string_end = string_data.iter().position(|&b| b == 0).unwrap_or(string_data.len());
+                        let string_end = string_data
+                            .iter()
+                            .position(|&b| b == 0)
+                            .unwrap_or(string_data.len());
                         let string_bytes = &string_data[..string_end];
-                        
+
                         let value = String::from_utf8_lossy(string_bytes).to_string();
                         println!("🔧 [DEBUG] Parsed alternative STRING (0x02A0): '{}'", value);
                         Ok(Some(PlcValue::String(value)))
                     }
-                    _ => {
-                        Err(BatchError::SerializationError(format!("Unsupported data type: 0x{:04X}", data_type)))
-                    }
+                    _ => Err(BatchError::SerializationError(format!(
+                        "Unsupported data type: 0x{:04X}",
+                        data_type
+                    ))),
                 }
             }
         }
@@ -2563,16 +2919,23 @@ impl EipClient {
 
     /// Writes a string value using Allen-Bradley UDT component access
     /// This writes to TestString.LEN and TestString.DATA separately
-    pub async fn write_ab_string_components(&mut self, tag_name: &str, value: &str) -> crate::error::Result<()> {
-        println!("🔧 [AB STRING] Writing string '{}' to tag '{}' using component access", value, tag_name);
-        
+    pub async fn write_ab_string_components(
+        &mut self,
+        tag_name: &str,
+        value: &str,
+    ) -> crate::error::Result<()> {
+        println!(
+            "🔧 [AB STRING] Writing string '{}' to tag '{}' using component access",
+            value, tag_name
+        );
+
         let string_bytes = value.as_bytes();
         let string_len = string_bytes.len() as i32;
-        
+
         // Step 1: Write the length to TestString.LEN
         let len_tag = format!("{}.LEN", tag_name);
         println!("   📝 Step 1: Writing length {} to {}", string_len, len_tag);
-        
+
         match self.write_tag(&len_tag, PlcValue::Dint(string_len)).await {
             Ok(_) => println!("   ✅ Length written successfully"),
             Err(e) => {
@@ -2580,22 +2943,28 @@ impl EipClient {
                 return Err(e);
             }
         }
-        
+
         // Step 2: Write the string data to TestString.DATA using array access
         println!("   📝 Step 2: Writing string data to {}.DATA", tag_name);
-        
+
         // We need to write each character individually to the DATA array
         for (i, &byte) in string_bytes.iter().enumerate() {
             let data_element = format!("{}.DATA[{}]", tag_name, i);
-            match self.write_tag(&data_element, PlcValue::Sint(byte as i8)).await {
+            match self
+                .write_tag(&data_element, PlcValue::Sint(byte as i8))
+                .await
+            {
                 Ok(_) => print!("."),
                 Err(e) => {
-                    println!("\n   ❌ Failed to write byte {} to position {}: {}", byte, i, e);
+                    println!(
+                        "\n   ❌ Failed to write byte {} to position {}: {}",
+                        byte, i, e
+                    );
                     return Err(e);
                 }
             }
         }
-        
+
         // Step 3: Clear remaining bytes (null terminate)
         if string_bytes.len() < 82 {
             let null_element = format!("{}.DATA[{}]", tag_name, string_bytes.len());
@@ -2604,54 +2973,66 @@ impl EipClient {
                 Err(e) => println!("\n   ⚠️ Could not null-terminate: {}", e),
             }
         }
-        
+
         println!("   🎉 AB STRING component write completed!");
         Ok(())
     }
-    
+
     /// Writes a string using a single UDT write with proper AB STRING format
-    pub async fn write_ab_string_udt(&mut self, tag_name: &str, value: &str) -> crate::error::Result<()> {
-        println!("🔧 [AB STRING UDT] Writing string '{}' to tag '{}' as UDT", value, tag_name);
-        
+    pub async fn write_ab_string_udt(
+        &mut self,
+        tag_name: &str,
+        value: &str,
+    ) -> crate::error::Result<()> {
+        println!(
+            "🔧 [AB STRING UDT] Writing string '{}' to tag '{}' as UDT",
+            value, tag_name
+        );
+
         let string_bytes = value.as_bytes();
         if string_bytes.len() > 82 {
-            return Err(EtherNetIpError::Protocol("String too long for Allen-Bradley STRING (max 82 chars)".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "String too long for Allen-Bradley STRING (max 82 chars)".to_string(),
+            ));
         }
-        
+
         // Build a CIP request that writes the complete AB STRING structure
         let mut cip_request = Vec::new();
-        
+
         // Service: Write Tag Service (0x4D)
         cip_request.push(0x4D);
-        
+
         // Request Path
         let tag_path = self.build_tag_path(tag_name);
         cip_request.push((tag_path.len() / 2) as u8); // Path size in words
         cip_request.extend_from_slice(&tag_path);
-        
+
         // Data Type: Allen-Bradley STRING (0x02A0) - but write as UDT components
         cip_request.extend_from_slice(&[0xA0, 0x00]); // UDT type
         cip_request.extend_from_slice(&[0x01, 0x00]); // Element count
-        
+
         // AB STRING UDT structure:
         // - DINT .LEN (4 bytes)
         // - SINT .DATA[82] (82 bytes)
-        
+
         // Write .LEN field (current string length)
         let len = string_bytes.len() as u32;
         cip_request.extend_from_slice(&len.to_le_bytes());
-        
+
         // Write .DATA field (82 bytes total)
         cip_request.extend_from_slice(string_bytes); // Actual string data
-        
+
         // Pad with zeros to reach 82 bytes
         let padding_needed = 82 - string_bytes.len();
         cip_request.extend_from_slice(&vec![0u8; padding_needed]);
-        
-        println!("   📦 Built UDT write request: {} bytes total", cip_request.len());
-        
+
+        println!(
+            "   📦 Built UDT write request: {} bytes total",
+            cip_request.len()
+        );
+
         let response = self.send_cip_request(&cip_request).await?;
-        
+
         if response.len() >= 3 {
             let general_status = response[2];
             if general_status == 0x00 {
@@ -2659,45 +3040,66 @@ impl EipClient {
                 Ok(())
             } else {
                 let error_msg = self.get_cip_error_message(general_status);
-                Err(EtherNetIpError::Protocol(format!("AB STRING UDT write failed - CIP Error 0x{:02X}: {}", general_status, error_msg)))
+                Err(EtherNetIpError::Protocol(format!(
+                    "AB STRING UDT write failed - CIP Error 0x{:02X}: {}",
+                    general_status, error_msg
+                )))
             }
         } else {
-            Err(EtherNetIpError::Protocol("Invalid AB STRING UDT write response".to_string()))
+            Err(EtherNetIpError::Protocol(
+                "Invalid AB STRING UDT write response".to_string(),
+            ))
         }
     }
-    
+
     /// Establishes a Class 3 connected session for STRING operations
-    /// 
+    ///
     /// Connected sessions are required for certain operations like STRING writes
     /// in Allen-Bradley PLCs. This implements the Forward Open CIP service.
     /// Will try multiple connection parameter configurations until one succeeds.
-    async fn establish_connected_session(&mut self, session_name: &str) -> crate::error::Result<ConnectedSession> {
-        println!("🔗 [CONNECTED] Establishing connected session: '{}'", session_name);
+    async fn establish_connected_session(
+        &mut self,
+        session_name: &str,
+    ) -> crate::error::Result<ConnectedSession> {
+        println!(
+            "🔗 [CONNECTED] Establishing connected session: '{}'",
+            session_name
+        );
         println!("🔗 [CONNECTED] Will try multiple parameter configurations...");
-        
+
         // Generate unique connection parameters
         *self.connection_sequence.lock().await += 1;
         let connection_serial = (*self.connection_sequence.lock().await & 0xFFFF) as u16;
-        
+
         // Try different configurations until one works
         for config_id in 0..=5 {
-            println!("\n🔧 [ATTEMPT {}] Trying configuration {}:", config_id + 1, config_id);
-            
+            println!(
+                "\n🔧 [ATTEMPT {}] Trying configuration {}:",
+                config_id + 1,
+                config_id
+            );
+
             let mut session = if config_id == 0 {
                 ConnectedSession::new(connection_serial)
             } else {
                 ConnectedSession::with_config(connection_serial, config_id)
             };
-            
+
             // Generate unique connection IDs for this attempt
-            session.o_to_t_connection_id = 0x20000000 + *self.connection_sequence.lock().await + (config_id as u32 * 0x1000);
-            session.t_to_o_connection_id = 0x30000000 + *self.connection_sequence.lock().await + (config_id as u32 * 0x1000);
-            
+            session.o_to_t_connection_id =
+                0x20000000 + *self.connection_sequence.lock().await + (config_id as u32 * 0x1000);
+            session.t_to_o_connection_id =
+                0x30000000 + *self.connection_sequence.lock().await + (config_id as u32 * 0x1000);
+
             // Build Forward Open request with this configuration
             let forward_open_request = self.build_forward_open_request(&session)?;
-            
-            println!("🔗 [ATTEMPT {}] Sending Forward Open request ({} bytes)", config_id + 1, forward_open_request.len());
-            
+
+            println!(
+                "🔗 [ATTEMPT {}] Sending Forward Open request ({} bytes)",
+                config_id + 1,
+                forward_open_request.len()
+            );
+
             // Send Forward Open request
             match self.send_cip_request(&forward_open_request).await {
                 Ok(response) => {
@@ -2709,147 +3111,172 @@ impl EipClient {
                             println!("   Connection ID: 0x{:08X}", session.connection_id);
                             println!("   O->T ID: 0x{:08X}", session.o_to_t_connection_id);
                             println!("   T->O ID: 0x{:08X}", session.t_to_o_connection_id);
-                            println!("   Using Connection ID: 0x{:08X} for messaging", session.connection_id);
-                            
+                            println!(
+                                "   Using Connection ID: 0x{:08X} for messaging",
+                                session.connection_id
+                            );
+
                             session.is_active = true;
                             let mut sessions = self.connected_sessions.lock().await;
                             sessions.insert(session_name.to_string(), session.clone());
                             return Ok(session);
-                        },
+                        }
                         Err(e) => {
-                            println!("❌ [ATTEMPT {}] Configuration {} failed: {}", config_id + 1, config_id, e);
-                            
+                            println!(
+                                "❌ [ATTEMPT {}] Configuration {} failed: {}",
+                                config_id + 1,
+                                config_id,
+                                e
+                            );
+
                             // If it's a specific status error, log it
                             if e.to_string().contains("status: 0x") {
                                 println!("   Status indicates: parameter incompatibility or resource conflict");
                             }
                         }
                     }
-                },
+                }
                 Err(e) => {
-                    println!("❌ [ATTEMPT {}] Network error with config {}: {}", config_id + 1, config_id, e);
+                    println!(
+                        "❌ [ATTEMPT {}] Network error with config {}: {}",
+                        config_id + 1,
+                        config_id,
+                        e
+                    );
                 }
             }
-            
+
             // Small delay between attempts
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        
+
         // If we get here, all configurations failed
         Err(EtherNetIpError::Protocol(
             "All connection parameter configurations failed. PLC may not support connected messaging or has reached connection limits.".to_string()
         ))
     }
-    
+
     /// Builds a Forward Open CIP request for establishing connected sessions
-    fn build_forward_open_request(&self, session: &ConnectedSession) -> crate::error::Result<Vec<u8>> {
-        let mut request = Vec::new();
-        
+    fn build_forward_open_request(
+        &self,
+        session: &ConnectedSession,
+    ) -> crate::error::Result<Vec<u8>> {
+        let mut request = Vec::with_capacity(50);
+
         // CIP Forward Open Service (0x54)
         request.push(0x54);
-        
+
         // Request path length (Connection Manager object)
         request.push(0x02); // 2 words
-        
+
         // Class ID: Connection Manager (0x06)
         request.push(0x20); // Logical Class segment
         request.push(0x06);
-        
+
         // Instance ID: Connection Manager instance (0x01)
         request.push(0x24); // Logical Instance segment
         request.push(0x01);
-        
+
         // Forward Open parameters
-        
+
         // Connection Timeout Ticks (1 byte) + Timeout multiplier (1 byte)
         request.push(0x0A); // Timeout ticks (10)
         request.push(session.timeout_multiplier);
-        
+
         // Originator -> Target Connection ID (4 bytes, little-endian)
         request.extend_from_slice(&session.o_to_t_connection_id.to_le_bytes());
-        
+
         // Target -> Originator Connection ID (4 bytes, little-endian)
         request.extend_from_slice(&session.t_to_o_connection_id.to_le_bytes());
-        
+
         // Connection Serial Number (2 bytes, little-endian)
         request.extend_from_slice(&session.connection_serial.to_le_bytes());
-        
+
         // Originator Vendor ID (2 bytes, little-endian)
         request.extend_from_slice(&session.originator_vendor_id.to_le_bytes());
-        
+
         // Originator Serial Number (4 bytes, little-endian)
         request.extend_from_slice(&session.originator_serial.to_le_bytes());
-        
+
         // Connection Timeout Multiplier (1 byte) - repeated for target
         request.push(session.timeout_multiplier);
-        
+
         // Reserved bytes (3 bytes)
         request.extend_from_slice(&[0x00, 0x00, 0x00]);
-        
+
         // Originator -> Target RPI (4 bytes, little-endian, microseconds)
         request.extend_from_slice(&session.rpi.to_le_bytes());
-        
+
         // Originator -> Target connection parameters (4 bytes)
         let o_to_t_params = self.encode_connection_parameters(&session.o_to_t_params);
         request.extend_from_slice(&o_to_t_params.to_le_bytes());
-        
+
         // Target -> Originator RPI (4 bytes, little-endian, microseconds)
         request.extend_from_slice(&session.rpi.to_le_bytes());
-        
+
         // Target -> Originator connection parameters (4 bytes)
         let t_to_o_params = self.encode_connection_parameters(&session.t_to_o_params);
         request.extend_from_slice(&t_to_o_params.to_le_bytes());
-        
+
         // Transport type/trigger (1 byte) - Class 3, Application triggered
         request.push(0xA3);
-        
+
         // Connection Path Size (1 byte)
         request.push(0x02); // 2 words for Message Router path
-        
+
         // Connection Path - Target the Message Router
         request.push(0x20); // Logical Class segment
         request.push(0x02); // Message Router class (0x02)
         request.push(0x24); // Logical Instance segment
         request.push(0x01); // Message Router instance (0x01)
-        
+
         Ok(request)
     }
-    
+
     /// Encodes connection parameters into a 32-bit value
     fn encode_connection_parameters(&self, params: &ConnectionParameters) -> u32 {
         let mut encoded = 0u32;
-        
+
         // Connection size (bits 0-15)
         encoded |= params.size as u32;
-        
+
         // Variable flag (bit 25)
         if params.variable_size {
             encoded |= 1 << 25;
         }
-        
+
         // Connection type (bits 29-30)
         encoded |= (params.connection_type as u32) << 29;
-        
+
         // Priority (bits 26-27)
         encoded |= (params.priority as u32) << 26;
-        
+
         encoded
     }
-    
+
     /// Parses Forward Open response and updates session with connection info
-    fn parse_forward_open_response(&self, session: &mut ConnectedSession, response: &[u8]) -> crate::error::Result<()> {
+    fn parse_forward_open_response(
+        &self,
+        session: &mut ConnectedSession,
+        response: &[u8],
+    ) -> crate::error::Result<()> {
         if response.len() < 2 {
-            return Err(EtherNetIpError::Protocol("Forward Open response too short".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Forward Open response too short".to_string(),
+            ));
         }
-        
+
         let service = response[0];
         let status = response[1];
-        
+
         // Check if this is a Forward Open Reply (0xD4)
         if service != 0xD4 {
-            return Err(EtherNetIpError::Protocol(format!("Unexpected service in Forward Open response: 0x{:02X}", service)));
+            return Err(EtherNetIpError::Protocol(format!(
+                "Unexpected service in Forward Open response: 0x{:02X}",
+                service
+            )));
         }
-        
+
         // Check status
         if status != 0x00 {
             let error_msg = match status {
@@ -2863,49 +3290,71 @@ impl EipClient {
                 0x26 => "Invalid parameter value - RPI or size out of range",
                 _ => &format!("Unknown status: 0x{:02X}", status),
             };
-            return Err(EtherNetIpError::Protocol(format!("Forward Open failed with status 0x{:02X}: {}", status, error_msg)));
+            return Err(EtherNetIpError::Protocol(format!(
+                "Forward Open failed with status 0x{:02X}: {}",
+                status, error_msg
+            )));
         }
-        
+
         // Parse successful response
         if response.len() < 16 {
-            return Err(EtherNetIpError::Protocol("Forward Open response data too short".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Forward Open response data too short".to_string(),
+            ));
         }
-        
+
         // CRITICAL FIX: The Forward Open response contains the actual connection IDs assigned by the PLC
         // Use the IDs returned by the PLC, not our requested ones
-        let actual_o_to_t_id = u32::from_le_bytes([response[2], response[3], response[4], response[5]]);
-        let actual_t_to_o_id = u32::from_le_bytes([response[6], response[7], response[8], response[9]]);
-        
+        let actual_o_to_t_id =
+            u32::from_le_bytes([response[2], response[3], response[4], response[5]]);
+        let actual_t_to_o_id =
+            u32::from_le_bytes([response[6], response[7], response[8], response[9]]);
+
         // Update session with the actual assigned connection IDs
         session.o_to_t_connection_id = actual_o_to_t_id;
         session.t_to_o_connection_id = actual_t_to_o_id;
-        session.connection_id = actual_o_to_t_id;  // Use O->T as the primary connection ID
-        
+        session.connection_id = actual_o_to_t_id; // Use O->T as the primary connection ID
+
         println!("✅ [FORWARD OPEN] Success!");
-        println!("   O->T Connection ID: 0x{:08X} (PLC assigned)", session.o_to_t_connection_id);
-        println!("   T->O Connection ID: 0x{:08X} (PLC assigned)", session.t_to_o_connection_id);
-        println!("   Using Connection ID: 0x{:08X} for messaging", session.connection_id);
-        
+        println!(
+            "   O->T Connection ID: 0x{:08X} (PLC assigned)",
+            session.o_to_t_connection_id
+        );
+        println!(
+            "   T->O Connection ID: 0x{:08X} (PLC assigned)",
+            session.t_to_o_connection_id
+        );
+        println!(
+            "   Using Connection ID: 0x{:08X} for messaging",
+            session.connection_id
+        );
+
         Ok(())
     }
-    
+
     /// Writes a string using connected explicit messaging
-    pub async fn write_string_connected(&mut self, tag_name: &str, value: &str) -> crate::error::Result<()> {
+    pub async fn write_string_connected(
+        &mut self,
+        tag_name: &str,
+        value: &str,
+    ) -> crate::error::Result<()> {
         let session_name = format!("string_write_{}", tag_name);
         let mut sessions = self.connected_sessions.lock().await;
-        
+
         if !sessions.contains_key(&session_name) {
             drop(sessions); // Release the lock before calling establish_connected_session
             self.establish_connected_session(&session_name).await?;
             sessions = self.connected_sessions.lock().await;
         }
-        
+
         let session = sessions.get(&session_name).unwrap().clone();
         let request = self.build_connected_string_write_request(tag_name, value, &session)?;
-        
+
         drop(sessions); // Release the lock before sending the request
-        let response = self.send_connected_cip_request(&request, &session, &session_name).await?;
-        
+        let response = self
+            .send_connected_cip_request(&request, &session, &session_name)
+            .await?;
+
         // Check if write was successful
         if response.len() >= 2 {
             let status = response[1];
@@ -2913,75 +3362,90 @@ impl EipClient {
                 Ok(())
             } else {
                 let error_msg = self.get_cip_error_message(status);
-                Err(EtherNetIpError::Protocol(format!("CIP Error 0x{:02X}: {}", status, error_msg)))
+                Err(EtherNetIpError::Protocol(format!(
+                    "CIP Error 0x{:02X}: {}",
+                    status, error_msg
+                )))
             }
         } else {
-            Err(EtherNetIpError::Protocol("Invalid connected string write response".to_string()))
+            Err(EtherNetIpError::Protocol(
+                "Invalid connected string write response".to_string(),
+            ))
         }
     }
-    
+
     /// Builds a string write request for connected messaging
-    fn build_connected_string_write_request(&self, tag_name: &str, value: &str, _session: &ConnectedSession) -> crate::error::Result<Vec<u8>> {
+    fn build_connected_string_write_request(
+        &self,
+        tag_name: &str,
+        value: &str,
+        _session: &ConnectedSession,
+    ) -> crate::error::Result<Vec<u8>> {
         let mut request = Vec::new();
-        
+
         // For connected messaging, use direct CIP Write service
         // The connection is already established, so we can send the request directly
-        
+
         // CIP Write Service Code
         request.push(0x4D);
-        
-        // Tag path - use simple ANSI format for connected messaging  
+
+        // Tag path - use simple ANSI format for connected messaging
         let tag_bytes = tag_name.as_bytes();
         let path_size_words = (2 + tag_bytes.len() + 1) / 2; // +1 for potential padding, /2 for word count
         request.push(path_size_words as u8);
-        
+
         request.push(0x91); // ANSI symbol segment
         request.push(tag_bytes.len() as u8); // Length of tag name
         request.extend_from_slice(tag_bytes);
-        
+
         // Add padding byte if needed to make path even length
         if (2 + tag_bytes.len()) % 2 != 0 {
             request.push(0x00);
         }
-        
+
         // Data type for AB STRING
         request.extend_from_slice(&[0xCE, 0x0F]); // AB STRING data type (4046)
-        
+
         // Number of elements (always 1 for a single string)
         request.extend_from_slice(&[0x01, 0x00]);
-        
+
         // Build the AB STRING structure payload
         let string_bytes = value.as_bytes();
         let max_len: u16 = 82; // Standard AB STRING max length
         let current_len = string_bytes.len().min(max_len as usize) as u16;
-        
+
         // STRING structure:
         // - Len (2 bytes) - number of characters used
         request.extend_from_slice(&current_len.to_le_bytes());
-        
-        // - MaxLen (2 bytes) - maximum characters allowed (typically 82)  
+
+        // - MaxLen (2 bytes) - maximum characters allowed (typically 82)
         request.extend_from_slice(&max_len.to_le_bytes());
-        
+
         // - Data[MaxLen] (82 bytes) - the character array, zero-padded
         let mut data_array = vec![0u8; max_len as usize];
         data_array[..current_len as usize].copy_from_slice(&string_bytes[..current_len as usize]);
         request.extend_from_slice(&data_array);
-        
-        println!("🔧 [DEBUG] Built connected string write request ({} bytes) for '{}' = '{}' (len={}, maxlen={})", 
+
+        println!("🔧 [DEBUG] Built connected string write request ({} bytes) for '{}' = '{}' (len={}, maxlen={})",
                  request.len(), tag_name, value, current_len, max_len);
         println!("🔧 [DEBUG] Request: {:02X?}", request);
-        
+
         Ok(request)
     }
-    
+
     /// Sends a CIP request using connected messaging
-    async fn send_connected_cip_request(&mut self, cip_request: &[u8], session: &ConnectedSession, session_name: &str) -> crate::error::Result<Vec<u8>> {
-        println!("🔗 [CONNECTED] Sending connected CIP request ({} bytes) using T->O connection ID 0x{:08X}", 
+    async fn send_connected_cip_request(
+        &mut self,
+        cip_request: &[u8],
+        session: &ConnectedSession,
+        session_name: &str,
+    ) -> crate::error::Result<Vec<u8>> {
+        println!("🔗 [CONNECTED] Sending connected CIP request ({} bytes) using T->O connection ID 0x{:08X}",
                  cip_request.len(), session.t_to_o_connection_id);
-        
+
         // Build EtherNet/IP header for connected data (Send RR Data)
         let mut packet = Vec::new();
-        
+
         // EtherNet/IP Header
         packet.extend_from_slice(&[0x6F, 0x00]); // Command: Send RR Data (0x006F) - correct for connected messaging
         packet.extend_from_slice(&[0x00, 0x00]); // Length (fill in later)
@@ -2989,34 +3453,34 @@ impl EipClient {
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Status
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]); // Context
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]); // Options
-        
+
         // CPF (Common Packet Format) data starts here
         let cpf_start = packet.len();
-        
+
         // Interface handle (4 bytes)
         packet.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
-        
+
         // Timeout (2 bytes) - 5 seconds
         packet.extend_from_slice(&[0x05, 0x00]);
-        
+
         // Item count (2 bytes) - 2 items: Address + Data
         packet.extend_from_slice(&[0x02, 0x00]);
-        
+
         // Item 1: Connected Address Item (specifies which connection to use)
         packet.extend_from_slice(&[0xA1, 0x00]); // Type: Connected Address Item (0x00A1)
         packet.extend_from_slice(&[0x04, 0x00]); // Length: 4 bytes
-        // Use T->O connection ID (Target to Originator) for addressing
+                                                 // Use T->O connection ID (Target to Originator) for addressing
         packet.extend_from_slice(&session.t_to_o_connection_id.to_le_bytes());
-        
+
         // Item 2: Connected Data Item (contains the CIP request + sequence)
         packet.extend_from_slice(&[0xB1, 0x00]); // Type: Connected Data Item (0x00B1)
         let data_length = cip_request.len() + 2; // +2 for sequence count
         packet.extend_from_slice(&(data_length as u16).to_le_bytes()); // Length
-        
+
         // Clone session_name and session before acquiring the lock
         let session_name_clone = session_name.to_string();
         let _session_clone = session.clone();
-        
+
         // Get the current session mutably to increment sequence counter
         let mut sessions = self.connected_sessions.lock().await;
         let current_sequence = if let Some(session_mut) = sessions.get_mut(&session_name_clone) {
@@ -3025,308 +3489,379 @@ impl EipClient {
         } else {
             1 // Fallback if session not found
         };
-        
+
         // Drop the lock before sending the request
         drop(sessions);
-        
+
         // Sequence count (2 bytes) - incremental counter for this connection
         packet.extend_from_slice(&current_sequence.to_le_bytes());
-        
+
         // CIP request data
         packet.extend_from_slice(cip_request);
-        
+
         // Update packet length in header (total CPF data size)
         let cpf_length = packet.len() - cpf_start;
         packet[2..4].copy_from_slice(&(cpf_length as u16).to_le_bytes());
-        
-        println!("🔗 [CONNECTED] Sending packet ({} bytes) with sequence {}", packet.len(), current_sequence);
-        
+
+        println!(
+            "🔗 [CONNECTED] Sending packet ({} bytes) with sequence {}",
+            packet.len(),
+            current_sequence
+        );
+
         // Send packet
         let mut stream = self.stream.lock().await;
-        stream.write_all(&packet).await
-            .map_err(|e| EtherNetIpError::Io(e))?;
-        
+        stream
+            .write_all(&packet)
+            .await
+            .map_err(EtherNetIpError::Io)?;
+
         // Read response header
         let mut header = [0u8; 24];
-        stream.read_exact(&mut header).await
-            .map_err(|e| EtherNetIpError::Io(e))?;
-        
+        stream
+            .read_exact(&mut header)
+            .await
+            .map_err(EtherNetIpError::Io)?;
+
         // Check EtherNet/IP command status
         let cmd_status = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
         if cmd_status != 0 {
-            return Err(EtherNetIpError::Protocol(format!("Connected message failed with status: 0x{:08X}", cmd_status)));
+            return Err(EtherNetIpError::Protocol(format!(
+                "Connected message failed with status: 0x{:08X}",
+                cmd_status
+            )));
         }
-        
+
         // Read response data
         let response_length = u16::from_le_bytes([header[2], header[3]]) as usize;
         let mut response_data = vec![0u8; response_length];
-        stream.read_exact(&mut response_data).await
-            .map_err(|e| EtherNetIpError::Io(e))?;
-        
+        stream
+            .read_exact(&mut response_data)
+            .await
+            .map_err(EtherNetIpError::Io)?;
+
         let mut last_activity = self.last_activity.lock().await;
         *last_activity = Instant::now();
-        
-        println!("🔗 [CONNECTED] Received response ({} bytes)", response_data.len());
-        
+
+        println!(
+            "🔗 [CONNECTED] Received response ({} bytes)",
+            response_data.len()
+        );
+
         // Extract connected CIP response
         self.extract_connected_cip_from_response(&response_data)
     }
-    
+
     /// Extracts CIP data from connected response
-    fn extract_connected_cip_from_response(&self, response: &[u8]) -> crate::error::Result<Vec<u8>> {
-        println!("🔗 [CONNECTED] Extracting CIP from connected response ({} bytes): {:02X?}", 
-                 response.len(), response);
-        
+    fn extract_connected_cip_from_response(
+        &self,
+        response: &[u8],
+    ) -> crate::error::Result<Vec<u8>> {
+        println!(
+            "🔗 [CONNECTED] Extracting CIP from connected response ({} bytes): {:02X?}",
+            response.len(),
+            response
+        );
+
         if response.len() < 12 {
-            return Err(EtherNetIpError::Protocol("Connected response too short for CPF header".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "Connected response too short for CPF header".to_string(),
+            ));
         }
-        
+
         // Parse CPF (Common Packet Format) structure
         // [0-3]: Interface handle
         // [4-5]: Timeout
         // [6-7]: Item count
         let item_count = u16::from_le_bytes([response[6], response[7]]) as usize;
         println!("🔗 [CONNECTED] CPF item count: {}", item_count);
-        
+
         let mut pos = 8; // Start after CPF header
-        
+
         // Look for Connected Data Item (0x00B1)
         for _i in 0..item_count {
             if pos + 4 > response.len() {
-                return Err(EtherNetIpError::Protocol("Response truncated while parsing items".to_string()));
+                return Err(EtherNetIpError::Protocol(
+                    "Response truncated while parsing items".to_string(),
+                ));
             }
-            
+
             let item_type = u16::from_le_bytes([response[pos], response[pos + 1]]);
             let item_length = u16::from_le_bytes([response[pos + 2], response[pos + 3]]) as usize;
             pos += 4; // Skip item header
-            
-            println!("🔗 [CONNECTED] Found item: type=0x{:04X}, length={}", item_type, item_length);
-            
-            if item_type == 0x00B1 { // Connected Data Item
+
+            println!(
+                "🔗 [CONNECTED] Found item: type=0x{:04X}, length={}",
+                item_type, item_length
+            );
+
+            if item_type == 0x00B1 {
+                // Connected Data Item
                 if pos + item_length > response.len() {
-                    return Err(EtherNetIpError::Protocol("Connected data item truncated".to_string()));
+                    return Err(EtherNetIpError::Protocol(
+                        "Connected data item truncated".to_string(),
+                    ));
                 }
-                
+
                 // Connected Data Item contains [sequence_count(2)][cip_data]
                 if item_length < 2 {
-                    return Err(EtherNetIpError::Protocol("Connected data item too short for sequence".to_string()));
+                    return Err(EtherNetIpError::Protocol(
+                        "Connected data item too short for sequence".to_string(),
+                    ));
                 }
-                
+
                 let sequence_count = u16::from_le_bytes([response[pos], response[pos + 1]]);
                 println!("🔗 [CONNECTED] Sequence count: {}", sequence_count);
-                
+
                 // Extract CIP data (skip 2-byte sequence count)
                 let cip_data = response[pos + 2..pos + item_length].to_vec();
-                println!("🔗 [CONNECTED] Extracted CIP data ({} bytes): {:02X?}", 
-                         cip_data.len(), cip_data);
-                
+                println!(
+                    "🔗 [CONNECTED] Extracted CIP data ({} bytes): {:02X?}",
+                    cip_data.len(),
+                    cip_data
+                );
+
                 return Ok(cip_data);
             } else {
                 // Skip this item's data
                 pos += item_length;
             }
         }
-        
-        Err(EtherNetIpError::Protocol("Connected Data Item (0x00B1) not found in response".to_string()))
+
+        Err(EtherNetIpError::Protocol(
+            "Connected Data Item (0x00B1) not found in response".to_string(),
+        ))
     }
-    
+
     /// Closes a specific connected session
     async fn close_connected_session(&mut self, session_name: &str) -> crate::error::Result<()> {
         if let Some(session) = self.connected_sessions.lock().await.get(session_name) {
             let session = session.clone(); // Clone to avoid borrowing issues
-            
+
             // Build Forward Close request
             let forward_close_request = self.build_forward_close_request(&session)?;
-            
+
             // Send Forward Close request
             let _response = self.send_cip_request(&forward_close_request).await?;
-            
-            println!("🔗 [CONNECTED] Session '{}' closed successfully", session_name);
+
+            println!(
+                "🔗 [CONNECTED] Session '{}' closed successfully",
+                session_name
+            );
         }
-        
+
         // Remove session from our tracking
         let mut sessions = self.connected_sessions.lock().await;
         sessions.remove(session_name);
-        
+
         Ok(())
     }
 
     /// Builds a Forward Close CIP request for terminating connected sessions
-    fn build_forward_close_request(&self, session: &ConnectedSession) -> crate::error::Result<Vec<u8>> {
-        let mut request = Vec::new();
-        
+    fn build_forward_close_request(
+        &self,
+        session: &ConnectedSession,
+    ) -> crate::error::Result<Vec<u8>> {
+        let mut request = Vec::with_capacity(21);
+
         // CIP Forward Close Service (0x4E)
         request.push(0x4E);
-        
+
         // Request path length (Connection Manager object)
         request.push(0x02); // 2 words
-        
+
         // Class ID: Connection Manager (0x06)
         request.push(0x20); // Logical Class segment
         request.push(0x06);
-        
-        // Instance ID: Connection Manager instance (0x01)  
+
+        // Instance ID: Connection Manager instance (0x01)
         request.push(0x24); // Logical Instance segment
         request.push(0x01);
-        
+
         // Forward Close parameters
-        
+
         // Connection Timeout Ticks (1 byte) + Timeout multiplier (1 byte)
         request.push(0x0A); // Timeout ticks (10)
         request.push(session.timeout_multiplier);
-        
+
         // Connection Serial Number (2 bytes, little-endian)
         request.extend_from_slice(&session.connection_serial.to_le_bytes());
-        
+
         // Originator Vendor ID (2 bytes, little-endian)
         request.extend_from_slice(&session.originator_vendor_id.to_le_bytes());
-        
+
         // Originator Serial Number (4 bytes, little-endian)
         request.extend_from_slice(&session.originator_serial.to_le_bytes());
-        
+
         // Connection Path Size (1 byte)
         request.push(0x02); // 2 words for Message Router path
-        
+
         // Connection Path - Target the Message Router
         request.push(0x20); // Logical Class segment
         request.push(0x02); // Message Router class (0x02)
-        request.push(0x24); // Logical Instance segment  
+        request.push(0x24); // Logical Instance segment
         request.push(0x01); // Message Router instance (0x01)
-        
+
         Ok(request)
     }
-     
+
     /// Closes all connected sessions (called during disconnect)
     async fn close_all_connected_sessions(&mut self) -> crate::error::Result<()> {
-        let session_names: Vec<String> = self.connected_sessions.lock().await.keys().cloned().collect();
-        
+        let session_names: Vec<String> = self
+            .connected_sessions
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect();
+
         for session_name in session_names {
             let _ = self.close_connected_session(&session_name).await; // Ignore errors during cleanup
         }
-        
+
         Ok(())
     }
 
     /// Writes a string using unconnected explicit messaging with proper AB STRING format
-    /// 
+    ///
     /// This method uses standard unconnected messaging instead of connected messaging
     /// and implements the proper Allen-Bradley STRING structure as described in the
     /// provided information about Len, MaxLen, and Data[82] format.
-    pub async fn write_string_unconnected(&mut self, tag_name: &str, value: &str) -> crate::error::Result<()> {
-        println!("📝 [UNCONNECTED] Writing string '{}' to tag '{}' using unconnected messaging", value, tag_name);
-        
+    pub async fn write_string_unconnected(
+        &mut self,
+        tag_name: &str,
+        value: &str,
+    ) -> crate::error::Result<()> {
+        println!(
+            "📝 [UNCONNECTED] Writing string '{}' to tag '{}' using unconnected messaging",
+            value, tag_name
+        );
+
         self.validate_session().await?;
-        
+
         let string_bytes = value.as_bytes();
         if string_bytes.len() > 82 {
-            return Err(EtherNetIpError::Protocol("String too long for Allen-Bradley STRING (max 82 chars)".to_string()));
+            return Err(EtherNetIpError::Protocol(
+                "String too long for Allen-Bradley STRING (max 82 chars)".to_string(),
+            ));
         }
-        
+
         // Build the CIP request with proper AB STRING structure
         let mut cip_request = Vec::new();
-        
+
         // Service: Write Tag Service (0x4D)
         cip_request.push(0x4D);
-        
+
         // Request Path Size (in words)
         let tag_bytes = tag_name.as_bytes();
-        let path_len = if tag_bytes.len() % 2 == 0 { 
-            tag_bytes.len() + 2 
-        } else { 
-            tag_bytes.len() + 3 
+        let path_len = if tag_bytes.len() % 2 == 0 {
+            tag_bytes.len() + 2
+        } else {
+            tag_bytes.len() + 3
         } / 2;
         cip_request.push(path_len as u8);
-        
+
         // Request Path: ANSI Extended Symbol Segment for tag name
         cip_request.push(0x91); // ANSI Extended Symbol Segment
         cip_request.push(tag_bytes.len() as u8); // Tag name length
         cip_request.extend_from_slice(tag_bytes); // Tag name
-        
+
         // Pad to even length if necessary
         if tag_bytes.len() % 2 != 0 {
             cip_request.push(0x00);
         }
-        
+
         // For write operations, we don't include data type and element count
         // The PLC infers the data type from the tag definition
-        
+
         // Build Allen-Bradley STRING structure based on what we see in read responses:
         // Looking at read response: [CE, 0F, 01, 00, 00, 00, 31, 00, ...]
         // Structure appears to be:
-        // - Some header/identifier (2 bytes): 0xCE, 0x0F  
+        // - Some header/identifier (2 bytes): 0xCE, 0x0F
         // - Length (2 bytes): number of characters
         // - MaxLength or padding (2 bytes): 0x00, 0x00
         // - Data array (variable length, null terminated)
-        
+
         let _current_len = string_bytes.len().min(82) as u16;
-        
+
         // Build the correct Allen-Bradley STRING structure to match what the PLC expects
         // Analysis of read response: [CE, 0F, 01, 00, 00, 00, 31, 00, 00, 00, ...]
         // Structure appears to be:
         // - Header (2 bytes): 0xCE, 0x0F (Allen-Bradley STRING identifier)
-        // - Length (4 bytes, DINT): Number of characters currently used  
+        // - Length (4 bytes, DINT): Number of characters currently used
         // - Data (variable): Character data followed by padding to complete the structure
-        
+
         let current_len = string_bytes.len().min(82) as u32;
-        
+
         // AB STRING header/identifier - this appears to be required
         cip_request.extend_from_slice(&[0xCE, 0x0F]);
-        
+
         // Length (4 bytes) - number of characters used as DINT
         cip_request.extend_from_slice(&current_len.to_le_bytes());
-        
+
         // Data bytes - the actual string content
         cip_request.extend_from_slice(&string_bytes[..current_len as usize]);
-        
+
         // Add padding if the total structure needs to be a specific size
         // Based on reads, it looks like there might be additional padding after the data
-        
-        println!("🔧 [DEBUG] Built Allen-Bradley STRING write request ({} bytes) for '{}' = '{}' (len={})", 
+
+        println!("🔧 [DEBUG] Built Allen-Bradley STRING write request ({} bytes) for '{}' = '{}' (len={})",
                  cip_request.len(), tag_name, value, current_len);
-        println!("🔧 [DEBUG] Request structure: Service=0x4D, Path={} bytes, Header=0xCE0F, Len={} (4 bytes), Data", 
+        println!("🔧 [DEBUG] Request structure: Service=0x4D, Path={} bytes, Header=0xCE0F, Len={} (4 bytes), Data",
                  path_len * 2, current_len);
-        
+
         // Send the request using standard unconnected messaging
         let response = self.send_cip_request(&cip_request).await?;
-        
+
         // Extract CIP response from EtherNet/IP wrapper
         let cip_response = self.extract_cip_from_response(&response)?;
-        
+
         // Check if write was successful - use correct CIP response format
         if cip_response.len() >= 3 {
-            let service_reply = cip_response[0];  // Should be 0xCD (0x4D + 0x80) for Write Tag reply
+            let service_reply = cip_response[0]; // Should be 0xCD (0x4D + 0x80) for Write Tag reply
             let _additional_status_size = cip_response[1]; // Additional status size (usually 0)
-            let status = cip_response[2];         // CIP status code at position 2
-            
-            println!("🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}", service_reply, status);
-            
+            let status = cip_response[2]; // CIP status code at position 2
+
+            println!(
+                "🔧 [DEBUG] Write response - Service: 0x{:02X}, Status: 0x{:02X}",
+                service_reply, status
+            );
+
             if status == 0x00 {
                 println!("✅ [UNCONNECTED] String write completed successfully");
                 Ok(())
             } else {
                 let error_msg = self.get_cip_error_message(status);
-                println!("❌ [UNCONNECTED] String write failed: {} (0x{:02X})", error_msg, status);
-                Err(EtherNetIpError::Protocol(format!("CIP Error 0x{:02X}: {}", status, error_msg)))
+                println!(
+                    "❌ [UNCONNECTED] String write failed: {} (0x{:02X})",
+                    error_msg, status
+                );
+                Err(EtherNetIpError::Protocol(format!(
+                    "CIP Error 0x{:02X}: {}",
+                    status, error_msg
+                )))
             }
         } else {
-            Err(EtherNetIpError::Protocol("Invalid unconnected string write response - too short".to_string()))
+            Err(EtherNetIpError::Protocol(
+                "Invalid unconnected string write response - too short".to_string(),
+            ))
         }
     }
 
     /// Write a string value to a PLC tag using unconnected messaging
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `tag_name` - The name of the tag to write to
     /// * `value` - The string value to write (max 82 characters)
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// * `Ok(())` if the write was successful
     /// * `Err(EtherNetIpError)` if the write failed
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// * `StringTooLong` - If the string is longer than 82 characters
     /// * `InvalidString` - If the string contains invalid characters
     /// * `TagNotFound` - If the tag doesn't exist
@@ -3349,13 +3884,13 @@ impl EipClient {
 
         // Build the string write request
         let request = self.build_string_write_request(tag_name, value)?;
-        
+
         // Send the request and get the response
         let response = self.send_cip_request(&request).await?;
-        
+
         // Parse the response
         let cip_response = self.extract_cip_from_response(&response)?;
-        
+
         // Check for errors in the response
         if cip_response.len() < 2 {
             return Err(crate::error::EtherNetIpError::InvalidResponse {
@@ -3375,36 +3910,44 @@ impl EipClient {
     }
 
     /// Build a string write request packet
-    fn build_string_write_request(&self, tag_name: &str, value: &str) -> crate::error::Result<Vec<u8>> {
+    fn build_string_write_request(
+        &self,
+        tag_name: &str,
+        value: &str,
+    ) -> crate::error::Result<Vec<u8>> {
         let mut request = Vec::new();
-        
+
         // CIP Write Service (0x4D)
         request.push(0x4D);
-        
+
         // Tag path
         let tag_path = self.build_tag_path(tag_name);
         request.extend_from_slice(&tag_path);
-        
+
         // AB STRING data structure
         request.extend_from_slice(&(value.len() as u16).to_le_bytes()); // Len
-        request.extend_from_slice(&82u16.to_le_bytes());                // MaxLen
-        
+        request.extend_from_slice(&82u16.to_le_bytes()); // MaxLen
+
         // Data[82] with padding
         let mut data = [0u8; 82];
         let bytes = value.as_bytes();
         data[..bytes.len()].copy_from_slice(bytes);
         request.extend_from_slice(&data);
-        
+
         Ok(request)
     }
 
     /// Subscribes to a tag for real-time updates
-    pub async fn subscribe_to_tag(&self, tag_path: &str, options: SubscriptionOptions) -> Result<()> {
+    pub async fn subscribe_to_tag(
+        &self,
+        tag_path: &str,
+        options: SubscriptionOptions,
+    ) -> Result<()> {
         let mut subscriptions = self.subscriptions.lock().await;
         let subscription = TagSubscription::new(tag_path.to_string(), options);
         subscriptions.push(subscription);
         drop(subscriptions); // Release the lock before starting the monitoring thread
-        
+
         let tag_path = tag_path.to_string();
         let mut client = self.clone();
         tokio::spawn(async move {
@@ -3444,7 +3987,10 @@ impl EipClient {
         Ok(())
     }
 
-    async fn _get_connected_session(&mut self, session_name: &str) -> crate::error::Result<ConnectedSession> {
+    async fn _get_connected_session(
+        &mut self,
+        session_name: &str,
+    ) -> crate::error::Result<ConnectedSession> {
         // First check if we already have a session
         {
             let sessions = self.connected_sessions.lock().await;
@@ -3455,11 +4001,11 @@ impl EipClient {
 
         // If we don't have a session, establish a new one
         let session = self.establish_connected_session(session_name).await?;
-        
+
         // Store the new session
         let mut sessions = self.connected_sessions.lock().await;
         sessions.insert(session_name.to_string(), session.clone());
-        
+
         Ok(session)
     }
 }
@@ -3472,7 +4018,7 @@ This file provides a complete, production-ready EtherNet/IP communication
 library for Allen-Bradley PLCs. The library includes:
 
 - Native Rust API with async support
-- C FFI exports for cross-language integration  
+- C FFI exports for cross-language integration
 - Comprehensive error handling and validation
 - Detailed documentation and examples
 - Performance optimizations

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-use tokio::net::TcpStream;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::time::{timeout, Duration};
-use std::error::Error;
 use std::collections::HashMap;
+use std::error::Error;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::{timeout, Duration};
 
 // Data type constants for CompactLogix
 #[derive(Debug, Clone, PartialEq)]
@@ -60,7 +60,7 @@ impl PlcValue {
             PlcValue::Raw(val) => val.clone(),
         }
     }
-    
+
     pub fn get_data_type(&self) -> u16 {
         match self {
             PlcValue::Bool(_) => PlcDataType::Bool as u16,
@@ -83,39 +83,45 @@ impl EipClient {
         println!("🔌 Connecting to CompactLogix PLC at {}...", addr);
         let stream = TcpStream::connect(addr).await?;
         println!("✅ TCP connection established");
-        
+
         let mut client = EipClient {
             stream,
             session_handle: 0,
             connection_info: HashMap::new(),
         };
-        
-        client.connection_info.insert("address".to_string(), addr.to_string());
+
+        client
+            .connection_info
+            .insert("address".to_string(), addr.to_string());
         client.register_session().await?;
         Ok(client)
     }
-    
+
     async fn register_session(&mut self) -> Result<(), Box<dyn Error>> {
         let packet: [u8; 28] = [
-            0x65, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x01, 0x00, 0x00, 0x00
+            0x65, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
         ];
-        
+
         self.stream.write_all(&packet).await?;
         println!("📤 Sent Register Session request");
-        
+
         let mut buf = [0u8; 1024];
         let n = timeout(Duration::from_secs(5), self.stream.read(&mut buf)).await??;
-        
+
         if n >= 8 {
             self.session_handle = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
             let status = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
-            
+
             if status == 0 && self.session_handle != 0 {
-                println!("🎯 Registration successful! Session ID: 0x{:08X}", self.session_handle);
-                self.connection_info.insert("session_id".to_string(), format!("0x{:08X}", self.session_handle));
+                println!(
+                    "🎯 Registration successful! Session ID: 0x{:08X}",
+                    self.session_handle
+                );
+                self.connection_info.insert(
+                    "session_id".to_string(),
+                    format!("0x{:08X}", self.session_handle),
+                );
                 Ok(())
             } else {
                 Err(format!("Registration failed. Status: 0x{:08X}", status).into())
@@ -124,61 +130,67 @@ impl EipClient {
             Err("Invalid registration response".into())
         }
     }
-    
+
     pub async fn read_tag(&mut self, tag_name: &str) -> Result<PlcValue, Box<dyn Error>> {
         let (data_type, raw_data) = self.read_tag_raw(tag_name).await?;
         self.parse_value(data_type.into(), &raw_data)
     }
-    
+
     async fn read_tag_raw(&mut self, tag_name: &str) -> Result<(u16, Vec<u8>), Box<dyn Error>> {
         let tag_bytes = tag_name.as_bytes();
         let mut cip_request = vec![0x4C, 0x00];
         let mut path = vec![0x91, tag_bytes.len() as u8];
         path.extend_from_slice(tag_bytes);
-        
+
         if path.len() % 2 != 0 {
             path.push(0x00);
         }
-        
+
         cip_request[1] = (path.len() / 2) as u8;
         cip_request.extend_from_slice(&path);
         cip_request.extend_from_slice(&[0x01, 0x00]);
-        
+
         let response = self.send_cip_request(&cip_request).await?;
         self.parse_cip_response(&response)
     }
-    
-    pub async fn write_tag(&mut self, tag_name: &str, value: PlcValue) -> Result<(), Box<dyn Error>> {
+
+    pub async fn write_tag(
+        &mut self,
+        tag_name: &str,
+        value: PlcValue,
+    ) -> Result<(), Box<dyn Error>> {
         let tag_bytes = tag_name.as_bytes();
         let value_bytes = value.to_bytes();
         let data_type = value.get_data_type();
-        
+
         let mut cip_request = vec![0x53, 0x02]; // Write Tag Service with verification
         let mut path = vec![0x91, tag_bytes.len() as u8];
         path.extend_from_slice(tag_bytes);
-        
+
         if path.len() % 2 != 0 {
             path.push(0x00);
         }
-        
+
         cip_request[1] = (path.len() / 2) as u8;
         cip_request.extend_from_slice(&path);
         cip_request.extend_from_slice(&data_type.to_le_bytes());
         cip_request.extend_from_slice(&[0x01, 0x00]);
         cip_request.extend_from_slice(&value_bytes);
-        
-        println!("📝 Writing {} to tag '{}'", 
-                 match &value {
-                     PlcValue::Bool(v) => format!("BOOL: {}", v),
-                     PlcValue::Dint(v) => format!("DINT: {}", v),
-                     PlcValue::Real(v) => format!("REAL: {}", v),
-                     PlcValue::String(v) => format!("STRING: '{}'", v),
-                     PlcValue::Raw(v) => format!("RAW: {:02X?}", v),
-                 }, 
-                 tag_name);
-        
+
+        println!(
+            "📝 Writing {} to tag '{}'",
+            match &value {
+                PlcValue::Bool(v) => format!("BOOL: {}", v),
+                PlcValue::Dint(v) => format!("DINT: {}", v),
+                PlcValue::Real(v) => format!("REAL: {}", v),
+                PlcValue::String(v) => format!("STRING: '{}'", v),
+                PlcValue::Raw(v) => format!("RAW: {:02X?}", v),
+            },
+            tag_name
+        );
+
         let response = self.send_cip_request(&cip_request).await?;
-        
+
         if response.len() >= 4 {
             let general_status = response[2];
             if general_status == 0x00 {
@@ -186,17 +198,24 @@ impl EipClient {
                 Ok(())
             } else {
                 let error_msg = self.get_cip_error_message(general_status);
-                Err(format!("Write failed - CIP Error 0x{:02X}: {}", general_status, error_msg).into())
+                Err(format!(
+                    "Write failed - CIP Error 0x{:02X}: {}",
+                    general_status, error_msg
+                )
+                .into())
             }
         } else {
             Err("Invalid write response".into())
         }
     }
-    
-    pub async fn read_multiple_tags(&mut self, tag_names: &[&str]) -> Result<HashMap<String, PlcValue>, Box<dyn Error>> {
+
+    pub async fn read_multiple_tags(
+        &mut self,
+        tag_names: &[&str],
+    ) -> Result<HashMap<String, PlcValue>, Box<dyn Error>> {
         let mut results = HashMap::new();
         println!("📋 Reading {} tags...", tag_names.len());
-        
+
         for tag_name in tag_names {
             match self.read_tag(tag_name).await {
                 Ok(value) => {
@@ -210,11 +229,14 @@ impl EipClient {
         }
         Ok(results)
     }
-    
-    pub async fn write_multiple_tags(&mut self, tags: HashMap<&str, PlcValue>) -> Result<Vec<String>, Box<dyn Error>> {
+
+    pub async fn write_multiple_tags(
+        &mut self,
+        tags: HashMap<&str, PlcValue>,
+    ) -> Result<Vec<String>, Box<dyn Error>> {
         let mut successful_writes = Vec::new();
         let total_tags = tags.len();
-        
+
         println!("📝 Writing {} tags...", total_tags);
         for (tag_name, value) in tags {
             match self.write_tag(tag_name, value).await {
@@ -226,25 +248,48 @@ impl EipClient {
                 }
             }
         }
-        
-        println!("✅ Successfully wrote {} of {} tags", successful_writes.len(), total_tags);
+
+        println!(
+            "✅ Successfully wrote {} of {} tags",
+            successful_writes.len(),
+            total_tags
+        );
         Ok(successful_writes)
     }
-    
-    pub async fn read_array_element(&mut self, tag_name: &str, index: u16) -> Result<PlcValue, Box<dyn Error>> {
+
+    pub async fn read_array_element(
+        &mut self,
+        tag_name: &str,
+        index: u16,
+    ) -> Result<PlcValue, Box<dyn Error>> {
         let array_tag = format!("{}[{}]", tag_name, index);
         self.read_tag(&array_tag).await
     }
-    
-    pub async fn write_array_element(&mut self, tag_name: &str, index: u16, value: PlcValue) -> Result<(), Box<dyn Error>> {
+
+    pub async fn write_array_element(
+        &mut self,
+        tag_name: &str,
+        index: u16,
+        value: PlcValue,
+    ) -> Result<(), Box<dyn Error>> {
         let array_tag = format!("{}[{}]", tag_name, index);
         self.write_tag(&array_tag, value).await
     }
-    
-    pub async fn read_array_range(&mut self, tag_name: &str, start_index: u16, count: u16) -> Result<Vec<PlcValue>, Box<dyn Error>> {
+
+    pub async fn read_array_range(
+        &mut self,
+        tag_name: &str,
+        start_index: u16,
+        count: u16,
+    ) -> Result<Vec<PlcValue>, Box<dyn Error>> {
         let mut results = Vec::new();
-        println!("📋 Reading array {}[{}..{}]", tag_name, start_index, start_index + count - 1);
-        
+        println!(
+            "📋 Reading array {}[{}..{}]",
+            tag_name,
+            start_index,
+            start_index + count - 1
+        );
+
         for i in start_index..start_index + count {
             match self.read_array_element(tag_name, i).await {
                 Ok(value) => {
@@ -259,81 +304,70 @@ impl EipClient {
         }
         Ok(results)
     }
-    
+
     pub async fn discover_tags(&mut self) -> Result<Vec<String>, Box<dyn Error>> {
         let mut discovered_tags = Vec::new();
         println!("🔍 Discovering available tags...");
-        
+
         let controller_tags = [
-            "Controller.Type", "Controller.MajorRev", "Controller.MinorRev",
-            "Controller.SerialNumber", "Controller.LastScan", "Controller.DateTime",
+            "Controller.Type",
+            "Controller.MajorRev",
+            "Controller.MinorRev",
+            "Controller.SerialNumber",
+            "Controller.LastScan",
+            "Controller.DateTime",
         ];
-        
+
         for tag in &controller_tags {
-            match self.read_tag(tag).await {
-                Ok(_) => {
-                    discovered_tags.push(tag.to_string());
-                    println!("✅ Found: {}", tag);
-                }
-                Err(_) => {}
+            if self.read_tag(tag).await.is_ok() {
+                discovered_tags.push(tag.to_string());
+                println!("✅ Found: {}", tag);
             }
         }
-        
+
         let program_names = ["MainProgram", "Program", "Main"];
         for program in &program_names {
             let program_tag = format!("Program:{}.TestTag", program);
-            match self.read_tag(&program_tag).await {
-                Ok(_) => {
-                    discovered_tags.push(program_tag);
-                    println!("✅ Found program: {}", program);
-                }
-                Err(_) => {}
+            if self.read_tag(&program_tag).await.is_ok() {
+                discovered_tags.push(program_tag);
+                println!("✅ Found program: {}", program);
             }
         }
-        
+
         Ok(discovered_tags)
     }
-    
+
     pub async fn get_controller_info(&mut self) -> Result<HashMap<String, String>, Box<dyn Error>> {
         let mut info = self.connection_info.clone();
-        
-        match self.read_tag("Controller.SerialNumber").await {
-            Ok(PlcValue::Dint(serial)) => {
-                info.insert("serial_number".to_string(), serial.to_string());
-            }
-            _ => {}
+
+        if let Ok(PlcValue::Dint(serial)) = self.read_tag("Controller.SerialNumber").await {
+            info.insert("serial_number".to_string(), serial.to_string());
         }
-        
-        match self.read_tag("Controller.Type").await {
-            Ok(PlcValue::Dint(controller_type)) => {
-                info.insert("controller_type".to_string(), controller_type.to_string());
-            }
-            _ => {}
+
+        if let Ok(PlcValue::Dint(controller_type)) = self.read_tag("Controller.Type").await {
+            info.insert("controller_type".to_string(), controller_type.to_string());
         }
-        
-        match self.read_tag("Controller.MajorRev").await {
-            Ok(PlcValue::Dint(major)) => {
-                info.insert("major_revision".to_string(), major.to_string());
-            }
-            _ => {}
+
+        if let Ok(PlcValue::Dint(major)) = self.read_tag("Controller.MajorRev").await {
+            info.insert("major_revision".to_string(), major.to_string());
         }
-        
-        match self.read_tag("Controller.MinorRev").await {
-            Ok(PlcValue::Dint(minor)) => {
-                info.insert("minor_revision".to_string(), minor.to_string());
-            }
-            _ => {}
+
+        if let Ok(PlcValue::Dint(minor)) = self.read_tag("Controller.MinorRev").await {
+            info.insert("minor_revision".to_string(), minor.to_string());
         }
-        
+
         Ok(info)
     }
-    
+
     pub async fn test_connectivity(&mut self) -> Result<HashMap<String, String>, Box<dyn Error>> {
         let mut status = HashMap::new();
-        
+
         status.insert("connection".to_string(), "OK".to_string());
-        status.insert("session_id".to_string(), format!("0x{:08X}", self.session_handle));
-        
+        status.insert(
+            "session_id".to_string(),
+            format!("0x{:08X}", self.session_handle),
+        );
+
         match self.read_tag("TestTag").await {
             Ok(_) => {
                 status.insert("read_test".to_string(), "PASS".to_string());
@@ -342,7 +376,7 @@ impl EipClient {
                 status.insert("read_test".to_string(), format!("FAIL: {}", e));
             }
         }
-        
+
         match self.write_tag("TestTag", PlcValue::Bool(false)).await {
             Ok(()) => {
                 status.insert("write_test".to_string(), "PASS".to_string());
@@ -351,14 +385,16 @@ impl EipClient {
                 status.insert("write_test".to_string(), format!("FAIL: {}", e));
             }
         }
-        
+
         Ok(status)
     }
-    
-    pub async fn benchmark_performance(&mut self) -> Result<HashMap<String, String>, Box<dyn Error>> {
+
+    pub async fn benchmark_performance(
+        &mut self,
+    ) -> Result<HashMap<String, String>, Box<dyn Error>> {
         let mut results = HashMap::new();
         println!("⚡ Running performance benchmarks...");
-        
+
         // Read performance test
         let start = std::time::Instant::now();
         let mut read_success = 0;
@@ -369,11 +405,14 @@ impl EipClient {
         }
         let read_duration = start.elapsed();
         let read_rate = (read_success as f64 / read_duration.as_secs_f64()) as u32;
-        
+
         println!("📊 Read performance: {} ops/sec", read_rate);
         results.insert("read_rate_per_sec".to_string(), read_rate.to_string());
-        results.insert("read_success_rate".to_string(), format!("{}/10", read_success));
-        
+        results.insert(
+            "read_success_rate".to_string(),
+            format!("{}/10", read_success),
+        );
+
         // Write performance test
         let start = std::time::Instant::now();
         let mut write_success = 0;
@@ -384,32 +423,35 @@ impl EipClient {
         }
         let write_duration = start.elapsed();
         let write_rate = (write_success as f64 / write_duration.as_secs_f64()) as u32;
-        
+
         println!("📊 Write performance: {} ops/sec", write_rate);
         results.insert("write_rate_per_sec".to_string(), write_rate.to_string());
-        results.insert("write_success_rate".to_string(), format!("{}/10", write_success));
-        
+        results.insert(
+            "write_success_rate".to_string(),
+            format!("{}/10", write_success),
+        );
+
         Ok(results)
     }
-    
+
     pub async fn safe_read_tag(&mut self, tag_name: &str) -> Option<PlcValue> {
         match self.read_tag(tag_name).await {
             Ok(value) => Some(value),
             Err(_) => None,
         }
     }
-    
+
     pub async fn safe_write_tag(&mut self, tag_name: &str, value: PlcValue) -> bool {
         match self.write_tag(tag_name, value).await {
             Ok(()) => true,
             Err(_) => false,
         }
     }
-    
+
     async fn send_cip_request(&mut self, cip_request: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
         let cip_len = cip_request.len();
         let total_data_len = 4 + 2 + 2 + 8 + cip_len;
-        
+
         let mut packet = vec![0x6F, 0x00];
         packet.extend_from_slice(&(total_data_len as u16).to_le_bytes());
         packet.extend_from_slice(&self.session_handle.to_le_bytes());
@@ -425,12 +467,12 @@ impl EipClient {
         packet.extend_from_slice(&[0xB2, 0x00]);
         packet.extend_from_slice(&(cip_len as u16).to_le_bytes());
         packet.extend_from_slice(cip_request);
-        
+
         self.stream.write_all(&packet).await?;
-        
+
         let mut buf = [0u8; 1024];
         let n = timeout(Duration::from_secs(10), self.stream.read(&mut buf)).await??;
-        
+
         if n >= 24 {
             let cmd_status = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
             if cmd_status == 0 {
@@ -442,52 +484,57 @@ impl EipClient {
             Err("Response too short".into())
         }
     }
-    
+
     fn extract_cip_from_response(&self, response: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
         let mut pos = 24;
         pos += 4;
         pos += 2;
-        let item_count = u16::from_le_bytes([response[pos], response[pos+1]]);
+        let item_count = u16::from_le_bytes([response[pos], response[pos + 1]]);
         pos += 2;
-        
+
         for _ in 0..item_count {
-            let item_type = u16::from_le_bytes([response[pos], response[pos+1]]);
+            let item_type = u16::from_le_bytes([response[pos], response[pos + 1]]);
             pos += 2;
-            let item_length = u16::from_le_bytes([response[pos], response[pos+1]]);
+            let item_length = u16::from_le_bytes([response[pos], response[pos + 1]]);
             pos += 2;
-            
+
             if item_type == 0x00B2 && item_length > 0 {
                 return Ok(response[pos..pos + item_length as usize].to_vec());
             }
-            
+
             pos += item_length as usize;
         }
-        
+
         Err("Could not find CIP response data".into())
     }
-    
+
     fn parse_cip_response(&self, cip_response: &[u8]) -> Result<(u16, Vec<u8>), Box<dyn Error>> {
         if cip_response.len() < 4 {
             return Err("CIP response too short".into());
         }
-        
+
         let general_status = cip_response[2];
         let additional_status_size = cip_response[3];
-        
+
         if general_status == 0x00 {
             let data_start = 4 + (additional_status_size as usize * 2);
             if data_start + 2 <= cip_response.len() {
-                let data_type = u16::from_le_bytes([cip_response[data_start], cip_response[data_start + 1]]);
+                let data_type =
+                    u16::from_le_bytes([cip_response[data_start], cip_response[data_start + 1]]);
                 let value_data = &cip_response[data_start + 2..];
                 return Ok((data_type, value_data.to_vec()));
             }
         }
-        
+
         let error_msg = self.get_cip_error_message(general_status);
         Err(format!("CIP Error 0x{:02X}: {}", general_status, error_msg).into())
     }
-    
-    fn parse_value(&self, data_type: PlcDataTypeExt, raw_data: &[u8]) -> Result<PlcValue, Box<dyn Error>> {
+
+    fn parse_value(
+        &self,
+        data_type: PlcDataTypeExt,
+        raw_data: &[u8],
+    ) -> Result<PlcValue, Box<dyn Error>> {
         match data_type {
             PlcDataTypeExt::Known(PlcDataType::Bool) => {
                 if !raw_data.is_empty() {
@@ -498,7 +545,8 @@ impl EipClient {
             }
             PlcDataTypeExt::Known(PlcDataType::Dint) => {
                 if raw_data.len() >= 4 {
-                    let value = i32::from_le_bytes([raw_data[0], raw_data[1], raw_data[2], raw_data[3]]);
+                    let value =
+                        i32::from_le_bytes([raw_data[0], raw_data[1], raw_data[2], raw_data[3]]);
                     Ok(PlcValue::Dint(value))
                 } else {
                     Err("Insufficient data for DINT value".into())
@@ -506,7 +554,8 @@ impl EipClient {
             }
             PlcDataTypeExt::Known(PlcDataType::Real) => {
                 if raw_data.len() >= 4 {
-                    let value = f32::from_le_bytes([raw_data[0], raw_data[1], raw_data[2], raw_data[3]]);
+                    let value =
+                        f32::from_le_bytes([raw_data[0], raw_data[1], raw_data[2], raw_data[3]]);
                     Ok(PlcValue::Real(value))
                 } else {
                     Err("Insufficient data for REAL value".into())
@@ -526,12 +575,10 @@ impl EipClient {
                     Err("No data for STRING value".into())
                 }
             }
-            PlcDataTypeExt::Unknown(_) => {
-                Ok(PlcValue::Raw(raw_data.to_vec()))
-            }
+            PlcDataTypeExt::Unknown(_) => Ok(PlcValue::Raw(raw_data.to_vec())),
         }
     }
-    
+
     fn get_cip_error_message(&self, status: u8) -> &'static str {
         match status {
             0x01 => "Connection failure",
@@ -565,19 +612,39 @@ impl EipClient {
             0x1D => "Missing attribute list entry data",
             0x1E => "Invalid attribute value list",
             0x1F => "Embedded service error",
-            _ => "Unknown error"
+            _ => "Unknown error",
         }
     }
-    
+
     pub async fn unregister_session(&mut self) -> Result<(), Box<dyn Error>> {
         let session_bytes = self.session_handle.to_le_bytes();
         let packet: [u8; 24] = [
-            0x66, 0x00, 0x00, 0x00,
-            session_bytes[0], session_bytes[1], session_bytes[2], session_bytes[3],
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x66,
+            0x00,
+            0x00,
+            0x00,
+            session_bytes[0],
+            session_bytes[1],
+            session_bytes[2],
+            session_bytes[3],
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
         ];
-        
+
         self.stream.write_all(&packet).await?;
         println!("📤 Session closed");
         Ok(())
@@ -588,16 +655,16 @@ impl EipClient {
 async fn main() -> Result<(), Box<dyn Error>> {
     println!("🦀 Rust EtherNet/IP Driver v2.0 - Complete Edition");
     println!("====================================================");
-    
+
     let mut client = EipClient::connect("192.168.0.1:44818").await?;
-    
+
     // Test 1: Read TestTag
     println!("\n🧪 TEST 1: Reading TestTag");
     match client.read_tag("TestTag").await {
         Ok(value) => println!("✅ TestTag value: {:?}", value),
         Err(e) => println!("❌ Failed to read TestTag: {}", e),
     }
-    
+
     // Test 2: Write TestTag
     println!("\n🧪 TEST 2: Writing to TestTag");
     match client.write_tag("TestTag", PlcValue::Bool(true)).await {
@@ -610,32 +677,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("❌ Failed to write TestTag: {}", e),
     }
-    
+
     // Test 3: Different Data Types
     println!("\n🧪 TEST 3: Testing Different Data Types");
-    
+
     println!("📝 Testing DINT operations...");
     match client.write_tag("TestDint", PlcValue::Dint(12345)).await {
-        Ok(()) => {
-            match client.read_tag("TestDint").await {
-                Ok(value) => println!("✅ DINT test: {:?}", value),
-                Err(e) => println!("⚠️ DINT read failed: {}", e),
-            }
-        }
+        Ok(()) => match client.read_tag("TestDint").await {
+            Ok(value) => println!("✅ DINT test: {:?}", value),
+            Err(e) => println!("⚠️ DINT read failed: {}", e),
+        },
         Err(e) => println!("⚠️ DINT write failed: {}", e),
     }
-    
+
     println!("📝 Testing REAL operations...");
     match client.write_tag("TestReal", PlcValue::Real(123.45)).await {
-        Ok(()) => {
-            match client.read_tag("TestReal").await {
-                Ok(value) => println!("✅ REAL test: {:?}", value),
-                Err(e) => println!("⚠️ REAL read failed: {}", e),
-            }
-        }
+        Ok(()) => match client.read_tag("TestReal").await {
+            Ok(value) => println!("✅ REAL test: {:?}", value),
+            Err(e) => println!("⚠️ REAL read failed: {}", e),
+        },
         Err(e) => println!("⚠️ REAL write failed: {}", e),
     }
-    
+
     // Test 4: Controller Information
     println!("\n🧪 TEST 4: Controller Information");
     match client.get_controller_info().await {
@@ -647,7 +710,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("⚠️ Could not get controller info: {}", e),
     }
-    
+
     // Test 5: Tag Discovery
     println!("\n🧪 TEST 5: Tag Discovery");
     match client.discover_tags().await {
@@ -663,7 +726,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("⚠️ Discovery error: {}", e),
     }
-    
+
     // Test 6: Multiple Tag Operations
     println!("\n🧪 TEST 6: Multiple Tag Operations");
     let test_tags = ["TestTag", "TestDint", "TestReal"];
@@ -676,27 +739,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("⚠️ Multiple tag read error: {}", e),
     }
-    
+
     // Test 7: Array Operations
     println!("\n🧪 TEST 7: Array Operations");
     println!("📝 Testing array operations (create TestArray[10] in your PLC)...");
-    match client.write_array_element("TestArray", 0, PlcValue::Dint(100)).await {
+    match client
+        .write_array_element("TestArray", 0, PlcValue::Dint(100))
+        .await
+    {
         Ok(()) => {
-            match client.write_array_element("TestArray", 1, PlcValue::Dint(200)).await {
-                Ok(()) => {
-                    match client.read_array_range("TestArray", 0, 3).await {
-                        Ok(values) => {
-                            println!("✅ Array operations successful! Values: {:?}", values);
-                        }
-                        Err(e) => println!("⚠️ Array read failed: {}", e),
+            match client
+                .write_array_element("TestArray", 1, PlcValue::Dint(200))
+                .await
+            {
+                Ok(()) => match client.read_array_range("TestArray", 0, 3).await {
+                    Ok(values) => {
+                        println!("✅ Array operations successful! Values: {:?}", values);
                     }
-                }
+                    Err(e) => println!("⚠️ Array read failed: {}", e),
+                },
                 Err(e) => println!("⚠️ Array write [1] failed: {}", e),
             }
         }
         Err(e) => println!("⚠️ Array write [0] failed (create TestArray[10]): {}", e),
     }
-    
+
     // Test 8: Connectivity Test
     println!("\n🧪 TEST 8: Connectivity Test");
     match client.test_connectivity().await {
@@ -708,7 +775,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("⚠️ Connectivity test error: {}", e),
     }
-    
+
     // Test 9: Performance Benchmark
     println!("\n🧪 TEST 9: Performance Benchmark");
     match client.benchmark_performance().await {
@@ -720,7 +787,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Err(e) => println!("⚠️ Benchmark error: {}", e),
     }
-    
+
     // Test 10: Safe Operations Demo
     println!("\n🧪 TEST 10: Safe Operations Demo");
     if let Some(value) = client.safe_read_tag("TestTag").await {
@@ -728,21 +795,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     } else {
         println!("⚠️ Safe read returned None");
     }
-    
-    if client.safe_write_tag("TestTag", PlcValue::Bool(false)).await {
+
+    if client
+        .safe_write_tag("TestTag", PlcValue::Bool(false))
+        .await
+    {
         println!("✅ Safe write successful");
     } else {
         println!("⚠️ Safe write failed");
     }
-    
+
     // Clean up
     client.unregister_session().await?;
-    
+
     println!("\n🎉 Complete EtherNet/IP Driver Test Finished!");
     println!("================================================");
     println!("✅ Your Rust EtherNet/IP library is production-ready!");
     println!("🚀 Features tested: Read/Write, Arrays, Discovery, Performance");
     println!("🔧 Ready for integration with C# or TypeScript!");
-    
+
     Ok(())
 }


### PR DESCRIPTION
There were a few places where a vector was created with Vec::new(), and then a static number of elements were pushed into it.

The use of Vec![] here with the elements might be more idiomatic, but interweaving all the comments it looked a bit strange. Since most of these vectors are a fixed number, we could potentially reduce allocations by calling Vec::with_capacity(), and allocate the correct amount of memory up front. It's possible the compiler could optimize these allocations away, but using with_capacity() should guarantee it.

There were a few Clippy lints I also cleaned up, some match blocks only on a single element, etc.

I ran cargo fmt after my changes as mentioned in the contributing guidlines, and it seemed to change a whole lot of lines....so this commit looks a bit messy. I'm not sure if you want me to redo this without running cargo fmt, so it doesn't change so much in one go.

