### PR TITLE
chore: remove default features from `futures` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,7 +1437,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1459,17 +1458,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -1534,7 +1522,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ tokio = { version = "1.0", features = [
 libc = "0.2"
 bytes = "1.0"
 thiserror = "2.0"
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 vergen = { version = "8.3", features = ["build", "git", "gitcl"] }


### PR DESCRIPTION
`futures::stream` doesn't require any additional feature flags for use. Removal cleans up the dependency tree for downstream consumers.