### PR TITLE
Add write_tag_verified for controllers that ack a write without applying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `EipClient::write_tag_verified` writes a tag and reads it back to confirm the
+  value was actually applied, returning the new `EtherNetIpError::WriteNotApplied`
+  if the read-back does not match. Motivated by a reproducible case against a
+  FactoryTalk Logix Echo-emulated ControlLogix 5580 (firmware 36) where an
+  Unconnected-Send-routed Write Tag Service reply carried CIP status `0x00`
+  (success) for a plain DINT tag while the value never changed; a second client
+  (pylogix, using a connected/Forward-Open session) writing the same tag
+  succeeded immediately after, ruling out a PLC-side lock. `write_tag` cannot
+  detect this itself — the false-success reply is indistinguishable on the wire
+  from a real one. Not yet confirmed on physical hardware; the existing 1.2.0
+  hardware validation (CompactLogix 5069-L330ERM fw38, 2285 writes, 0 anomalies)
+  found no equivalent case, so this may be Echo-specific. New simulator
+  behavior `SimBehavior::ghost_write_tags` reproduces the scenario for
+  regression coverage. See `docs/validation/` for the write-up.
+
 ## [1.2.0] - 2026-07-08
 
 Minor release: behavioral fixes, deprecations, and additive surface (C/C++ header

--- a/docs/validation/2026-07-12_echo_write_not_applied_5580_fw36.md
+++ b/docs/validation/2026-07-12_echo_write_not_applied_5580_fw36.md
@@ -1,0 +1,102 @@
+# 2026-07-12 write acknowledged-but-not-applied — FactoryTalk Logix Echo 5580 fw36
+
+Date: 2026-07-12
+Library version: `1.2.0` (`main`)
+Trigger: independent evaluation of the crate as a candidate dependency for a third-party
+project, prototyping tag reads/writes against a live FactoryTalk Logix Echo instance.
+
+## Headline
+
+A plain controller-scope DINT tag on a FactoryTalk Logix Echo-emulated ControlLogix 5580
+(firmware 36) accepted a `write_tag` call with a clean CIP success reply (Write Tag Service,
+service `0xCD`, status `0x00`) while the underlying value never changed. The request bytes are
+correctly formed (confirmed via `RUST_LOG=rust_ethernet_ip=trace`) and the controller's own
+reply claims success, so `write_tag` cannot detect this at the protocol level — the reply is
+indistinguishable on the wire from a real success. This is reported as a caution and mitigated
+with a new opt-in verified-write API (`EipClient::write_tag_verified`), not as a wire-encoding
+fix, because no incorrect encoding was found.
+
+## Setup
+
+- Controller: FactoryTalk Logix Echo-emulated **ControlLogix 5580** ("Emulate 5580 Controller"
+  per CIP List-Identity), firmware **36.11**, at `<echo-host>:44818`, backplane slot **1**
+  (`RoutePath::new().add_backplane(1, 1)`), reachable directly over a real LAN (Echo was
+  configured with a routable IP, not the default `127.0.0.1`/loopback binding).
+- Loaded project: a production controller export (~1100 tags), not a minimal test program.
+- Tag: controller-scope `Spare_DInt` (DINT), a generic scratch tag.
+- Cross-validation client: [pylogix](https://github.com/dmroeder/pylogix) 1.1.5, same
+  controller, same tag, same slot.
+
+## Reproduction
+
+```rust
+let route = RoutePath::new().add_backplane(1, 1);
+let mut client = EipClient::with_route_path("<echo-host>:44818", route).await?;
+
+let before = client.read_tag("Spare_DInt").await?;         // Dint(37)
+client.write_tag("Spare_DInt", PlcValue::Dint(4242)).await?; // Ok(())
+let after = client.read_tag("Spare_DInt").await?;            // Dint(37) — unchanged
+```
+
+Reproduced 3/3 attempts across both the same connection and a fresh connection per attempt.
+Five other DINT/STRING scratch tags on the same controller, through the same client and
+connection, wrote and read back correctly in the same session (`_testAdd`,
+`Program:Optimization_MG._rsETest`, `Program:TableInfeedChains._thTestCopyData1`,
+`_th_VFDTEST`, `_TH_VFDTEST`, `StringGeneral`) — this is not a systemic type-encoding
+regression, it is narrower and at minimum tag-dependent.
+
+## Wire evidence
+
+`RUST_LOG=rust_ethernet_ip=trace` on the write to `Spare_DInt`:
+
+```
+Built CIP write request (22 bytes): 4D 06 91 0A 53 70 61 72 65 5F 44 49 6E 74 C4 00 01 00 92 10 00 00
+...
+Received response (20 bytes): ... B2 00 04 00 CD 00 00 00
+Write response - Service: 0xCD, Status: 0x00
+```
+
+Decoding the request: service `0x4D` (Write Tag Service), symbolic path `Spare_DInt`, type
+`0x00C4` (DINT), count `1`, value `92 10 00 00` LE = `0x00001092` = `4242` — a correctly formed
+request for the intended value. The reply's embedded service is `0xCD` (Write Tag Service
+Reply) with general status `0x00` (success) — not the `0xD2` Unconnected Send failure shape
+covered by [`docs/agents/notes/unconnected-send.md`](../agents/notes/unconnected-send.md). The
+subsequent read, framed identically (same route path, same symbolic path resolution), returns
+`25 00 00 00` LE = `37` — the pre-write value.
+
+A packet capture of pylogix's successful write to the same tag shows its SendRRData items use
+encapsulation item type `0x00A1` (Connected Address Item), i.e. pylogix holds a real CIP
+connection (Forward Open) for its explicit messaging, whereas this library always wraps CIP
+requests in Unconnected Send (item type `0x00B2`) — see
+[`docs/agents/notes/unconnected-send.md`](../agents/notes/unconnected-send.md), "Unconnected
+Send (service `0x52`) is the primary path, always". The write payload bytes themselves are
+otherwise the same shape (service `0x4D`, type `0x00C4`, count `1`, little-endian value) between
+the two clients. Whether the connected-vs-unconnected distinction is the actual mechanism behind
+the discrepancy is not confirmed here — it is offered as the leading, but unproven, explanation.
+
+## Interpretation
+
+1. The request encoding is correct; this is not a repeat of the STRING/UDT firmware-quirk class
+   documented in [`docs/agents/notes/ab-firmware-quirks.md`](../agents/notes/ab-firmware-quirks.md)
+   (those surface as an explicit non-zero CIP status). Here the controller's own reply claims
+   success.
+2. This has not been observed on physical hardware. The existing 1.2.0 hardware validation
+   (CompactLogix 5069-L330ERM fw38: 2304 reads, 2285 writes, 2285 verify, 0 anomalies — see
+   `docs/validation/2026-07-08_cross-binding_full-coverage_5069-L330ERM_fw38.md`) found no
+   equivalent case. Treat this as an Echo-specific caution, not a general claim about the
+   library or about Allen-Bradley firmware, until it is reproduced (or ruled out) against
+   physical hardware.
+3. Because the false-success reply is wire-indistinguishable from a true one, no client-side
+   parsing fix is possible. The mitigation implemented alongside this report is an explicit,
+   opt-in verified-write primitive (`EipClient::write_tag_verified`) that reads back after
+   writing and returns `EtherNetIpError::WriteNotApplied` on mismatch, plus a
+   `SimBehavior::ghost_write_tags` simulator hook so the failure mode has deterministic
+   regression coverage without requiring the Echo instance that surfaced it.
+
+## Open follow-ups
+
+- Reproduce (or rule out) against physical ControlLogix/CompactLogix hardware.
+- Determine whether the Unconnected-Send-only design (vs. a Forward-Open/connected mode, which
+  pylogix uses) is actually the mechanism, or coincidental.
+- Consider whether `write_tag_verified` should become the default `write_tag` behavior behind a
+  config flag, given the cost is one extra read per write.

--- a/src/client.rs
+++ b/src/client.rs
@@ -304,7 +304,8 @@ fn diagnostic_error_category(error: &EtherNetIpError) -> crate::ErrorCategory {
         | EtherNetIpError::InvalidString { .. } => crate::ErrorCategory::DataType,
         EtherNetIpError::ReadError { .. }
         | EtherNetIpError::WriteError { .. }
-        | EtherNetIpError::CipError { .. } => crate::ErrorCategory::CipProtocol,
+        | EtherNetIpError::CipError { .. }
+        | EtherNetIpError::WriteNotApplied { .. } => crate::ErrorCategory::CipProtocol,
         EtherNetIpError::Protocol(message)
             if message.contains("route") || message.contains("Route") =>
         {
@@ -3092,6 +3093,57 @@ impl EipClient {
         }
 
         self.write_tag_direct(tag_name, &value).await
+    }
+
+    /// Writes a tag, then reads it back and confirms the value was actually applied.
+    ///
+    /// `write_tag` reports success whenever the controller's Write Tag Service reply
+    /// carries CIP status `0x00`. That reply is normally trustworthy, but at least one
+    /// controller (a FactoryTalk Logix Echo-emulated ControlLogix 5580, firmware 36) has
+    /// been observed acknowledging an Unconnected-Send-routed write to a plain DINT tag
+    /// with status `0x00` while the tag's value never changed — confirmed by an
+    /// independent client (pylogix, using a connected/Forward-Open session) writing the
+    /// same tag successfully immediately after. `write_tag` cannot detect this at the
+    /// protocol level, because the false-success reply is indistinguishable on the wire
+    /// from a real one. Callers that need certainty a write was actually applied should
+    /// use this method in place of `write_tag` followed by a manual read.
+    ///
+    /// Whether this also occurs against physical hardware is not yet confirmed; treat it
+    /// as an Echo-specific caution until proven otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EtherNetIpError::WriteNotApplied`] if the read-back value does not equal
+    /// the written value. Returns any error `write_tag` or `read_tag` would return for
+    /// other failure modes (the write's error, if any, takes precedence over the read).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    /// # let mut client = rust_ethernet_ip::EipClient::connect("192.168.1.100:44818").await?;
+    /// use rust_ethernet_ip::PlcValue;
+    ///
+    /// client.write_tag_verified("Counter", PlcValue::Dint(42)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn write_tag_verified(
+        &mut self,
+        tag_name: &str,
+        value: PlcValue,
+    ) -> crate::error::Result<()> {
+        self.write_tag(tag_name, value.clone()).await?;
+        let readback = self.read_tag(tag_name).await?;
+        if readback == value {
+            Ok(())
+        } else {
+            Err(crate::error::EtherNetIpError::WriteNotApplied {
+                tag_name: tag_name.to_string(),
+                expected: format!("{value:?}"),
+                actual: format!("{readback:?}"),
+            })
+        }
     }
 
     async fn write_tag_direct(

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,23 @@ pub enum EtherNetIpError {
         /// Reason the API is unsupported and the replacement to use.
         reason: &'static str,
     },
+
+    /// The controller acknowledged a Write Tag Service request with a success
+    /// status, but a read-back of the same tag shows the value was never
+    /// actually applied. Observed against an Unconnected-Send-routed write on a
+    /// FactoryTalk Logix Echo-emulated ControlLogix 5580 (firmware 36); not yet
+    /// confirmed on physical hardware. See `write_tag_verified`.
+    #[error(
+        "Write to '{tag_name}' was acknowledged by the controller but not applied: expected {expected}, read back {actual}"
+    )]
+    WriteNotApplied {
+        /// Tag path that was written.
+        tag_name: String,
+        /// Debug-formatted value that was written.
+        expected: String,
+        /// Debug-formatted value read back immediately after the write.
+        actual: String,
+    },
 }
 
 impl EtherNetIpError {

--- a/src/monitoring.rs
+++ b/src/monitoring.rs
@@ -399,6 +399,7 @@ impl ProductionMonitor {
             EtherNetIpError::Unsupported { .. } => ErrorCategory::CipProtocol,
             EtherNetIpError::StringTooLong { .. } => ErrorCategory::DataType,
             EtherNetIpError::Utf8(_) => ErrorCategory::DataType,
+            EtherNetIpError::WriteNotApplied { .. } => ErrorCategory::CipProtocol,
         }
     }
 

--- a/src/tag_group.rs
+++ b/src/tag_group.rs
@@ -76,6 +76,7 @@ impl TagGroupFailureDiagnostic {
             | EtherNetIpError::WriteError { status, .. } => {
                 (TagGroupFailureCategory::PlcStatus, Some(*status))
             }
+            EtherNetIpError::WriteNotApplied { .. } => (TagGroupFailureCategory::PlcStatus, None),
             EtherNetIpError::Permission(_) => (TagGroupFailureCategory::Permission, None),
             EtherNetIpError::TagNotFound(_) | EtherNetIpError::Tag(_) => {
                 (TagGroupFailureCategory::Tag, None)

--- a/tests/plc_sim.rs
+++ b/tests/plc_sim.rs
@@ -93,6 +93,14 @@ pub struct SimBehavior {
     pub count_reads_as_dint_tags: Vec<String>,
     /// Tags that should fail WRITE requests with CIP status 0x04.
     pub fail_write_tags: Vec<String>,
+    /// Tags whose WRITE requests reply with CIP status 0x00 (success) but the
+    /// underlying stored value is left unchanged. Models the FactoryTalk Logix
+    /// Echo behavior observed 2026-07-12 on a ControlLogix 5580 emulator
+    /// (firmware 36): an Unconnected-Send-routed Write Tag Service request to a
+    /// plain DINT tag returned a clean success reply while the value never
+    /// changed, cross-validated against a second client (pylogix, connected
+    /// session) writing the same tag successfully. Exercises `write_tag_verified`.
+    pub ghost_write_tags: Vec<String>,
 }
 
 struct SimRuntimeBehavior {
@@ -164,6 +172,13 @@ impl SimRuntimeBehavior {
     fn should_fail_write(&self, tag_name: &str) -> bool {
         self.config
             .fail_write_tags
+            .iter()
+            .any(|configured| configured == tag_name)
+    }
+
+    fn should_ghost_write(&self, tag_name: &str) -> bool {
+        self.config
+            .ghost_write_tags
             .iter()
             .any(|configured| configured == tag_name)
     }
@@ -780,6 +795,12 @@ fn handle_write_cip_request(
     let Some(value) = value else {
         return build_cip_error_reply(CIP_REPLY_WRITE, CIP_STATUS_PATH_SEGMENT_ERROR);
     };
+
+    if behavior.should_ghost_write(&tag_name) {
+        // Reply success without touching the stored value — models a controller
+        // that acknowledges a write it never actually applies.
+        return build_cip_ok_write_reply();
+    }
 
     let mut tags = tags.lock().expect("tag lock");
     if let Some(index) = element_index

--- a/tests/plc_sim_tests.rs
+++ b/tests/plc_sim_tests.rs
@@ -721,3 +721,84 @@ async fn simulated_plc_partial_batch_failures_are_isolated() {
         other => panic!("expected CIP error for failed tag, got: {:?}", other),
     }
 }
+
+// Regression coverage for a controller that acknowledges a write it never applies.
+// See CHANGELOG "Unreleased" and docs/validation for the FactoryTalk Logix Echo repro
+// this models: an Unconnected-Send-routed Write Tag Service reply carried CIP status
+// 0x00 (success) for a plain DINT tag, but the value never changed.
+
+#[tokio::test]
+async fn simulated_plc_write_tag_reports_success_even_when_ghosted() {
+    // `write_tag` alone cannot see this failure mode — the reply it trusts is a lie.
+    let sim = SimulatedPlc::start_with_behavior(SimBehavior {
+        ghost_write_tags: vec!["DINT_TAG".to_string()],
+        ..Default::default()
+    })
+    .await;
+    let addr = format!("{}", sim.address);
+
+    let mut client = EipClient::connect(&addr).await.expect("connect");
+    let before = client.read_tag("DINT_TAG").await.expect("read before");
+    assert_eq!(before, PlcValue::Dint(1234));
+
+    client
+        .write_tag("DINT_TAG", PlcValue::Dint(9999))
+        .await
+        .expect("write_tag reports success (this is the bug being modeled)");
+
+    let after = client.read_tag("DINT_TAG").await.expect("read after");
+    assert_eq!(
+        after,
+        PlcValue::Dint(1234),
+        "value must be unchanged — the simulated controller ghosted the write"
+    );
+}
+
+#[tokio::test]
+async fn simulated_plc_write_tag_verified_detects_ghosted_write() {
+    let sim = SimulatedPlc::start_with_behavior(SimBehavior {
+        ghost_write_tags: vec!["DINT_TAG".to_string()],
+        ..Default::default()
+    })
+    .await;
+    let addr = format!("{}", sim.address);
+
+    let mut client = EipClient::connect(&addr).await.expect("connect");
+    let err = client
+        .write_tag_verified("DINT_TAG", PlcValue::Dint(9999))
+        .await
+        .expect_err("write_tag_verified must surface the ghosted write");
+
+    match err {
+        EtherNetIpError::WriteNotApplied {
+            tag_name,
+            expected,
+            actual,
+        } => {
+            assert_eq!(tag_name, "DINT_TAG");
+            assert_eq!(expected, format!("{:?}", PlcValue::Dint(9999)));
+            assert_eq!(actual, format!("{:?}", PlcValue::Dint(1234)));
+        }
+        other => panic!("expected WriteNotApplied, got: {other:?}"),
+    }
+
+    // The tag must be left genuinely unchanged — no partial/side-effect state.
+    let value = client.read_tag("DINT_TAG").await.expect("read after");
+    assert_eq!(value, PlcValue::Dint(1234));
+}
+
+#[tokio::test]
+async fn simulated_plc_write_tag_verified_passes_through_normal_writes() {
+    // Sanity check: verified writes must not regress the common, correct case.
+    let sim = SimulatedPlc::start().await;
+    let addr = format!("{}", sim.address);
+
+    let mut client = EipClient::connect(&addr).await.expect("connect");
+    client
+        .write_tag_verified("DINT_TAG", PlcValue::Dint(555))
+        .await
+        .expect("verified write of a genuinely-applied value must succeed");
+
+    let value = client.read_tag("DINT_TAG").await.expect("read after");
+    assert_eq!(value, PlcValue::Dint(555));
+}


### PR DESCRIPTION
## Summary

Reproduced against a FactoryTalk Logix Echo-emulated ControlLogix 5580 (firmware 36): an Unconnected-Send-routed Write Tag Service request to a plain DINT tag returned CIP status `0x00` (success) while the value never changed. The request bytes are correctly encoded (verified via `RUST_LOG=rust_ethernet_ip=trace`) and the controller's own reply claims success, so `write_tag` cannot detect this at the protocol level — the false-success reply is indistinguishable on the wire from a real one.

Cross-validated against [pylogix](https://github.com/dmroeder/pylogix) 1.1.5, which wrote the same tag successfully via a connected (Forward Open) session immediately after — ruling out a PLC-side lock or a bad tag. Five other DINT/STRING tags on the same controller, through this crate's client in the same session, wrote correctly, so it isn't a systemic type-encoding regression.

This is **not proposed as a wire-encoding fix** — no incorrect encoding was found, and the existing 1.2.0 hardware validation (5069-L330ERM fw38: 2285 writes, 0 anomalies) found no equivalent case, so this may well be Echo-specific rather than a general library or firmware issue. Full write-up, wire evidence, and open follow-ups are in `docs/validation/2026-07-12_echo_write_not_applied_5580_fw36.md`.

## What's added

- `EipClient::write_tag_verified(tag, value)` — writes, then reads back, and returns the new `EtherNetIpError::WriteNotApplied { tag_name, expected, actual }` on mismatch. Opt-in; `write_tag` is unchanged.
- `SimBehavior::ghost_write_tags` in the `plc_sim` test harness — models a controller that replies success without applying the write, so the failure mode has deterministic regression coverage independent of Echo/hardware access.
- Three new tests in `tests/plc_sim_tests.rs`: the ghosted-write behavior is observable via plain `write_tag` (documents the bug being modeled), `write_tag_verified` detects it, and `write_tag_verified` passes through normal (correctly-applied) writes without regressing the common case.
- `CHANGELOG.md` under `Unreleased`, and a `docs/validation/` entry following the existing report format.

`EtherNetIpError` is `#[non_exhaustive]`, but the new variant still required updating three in-crate exhaustive matches (`src/monitoring.rs`, `src/tag_group.rs`, `src/client.rs::diagnostic_error_category`) — all classified as `CipProtocol` / `PlcStatus` alongside the existing `CipError`/`ReadError`/`WriteError` variants.

## Test plan

```
cargo fmt -- --check                                 # clean
cargo clippy -p rust-ethernet-ip --lib -- -D warnings # clean
cargo build --features ffi                            # clean (no FFI surface touched)
SKIP_PLC_TESTS=1 cargo test --workspace --all-targets  # all green
cargo test --test plc_sim_tests                        # 28 passed, including the 3 new tests
```

Not run: `dotnet test csharp/RustEtherNetIp.Tests` (no .NET SDK in the environment this was authored in) and anything against physical hardware (no hardware access). This PR doesn't touch the FFI/C# surface, so risk there should be limited, but flagging per the contribution checklist rather than silently skipping it.

## Risk notes

- Purely additive: new error variant (non-exhaustive enum, so external `match`es without a wildcard won't break — only the three in-crate matches needed updates, all handled), new method, new test-only sim behavior. `write_tag` itself is untouched.
- The root cause (why the controller's own reply lies) is not established — the packet-capture comparison against pylogix's connected-session write is offered as the leading lead (see the validation doc), not a proven mechanism. Happy to dig further if that's useful before merge, or split it into a follow-up issue.