### PR TITLE
build: lower and centralize workspace MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,16 +171,26 @@ jobs:
       run: python -m unittest discover -v tests
 
   msrv:
-    name: MSRV (1.96)
+    name: MSRV
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.96.0
+    - name: Read MSRV from workspace manifest
+      id: msrv
+      shell: bash
+      run: |
+        msrv="$(sed -n 's/^rust-version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+        test -n "$msrv"
+        echo "version=$msrv" >> "$GITHUB_OUTPUT"
+    - name: Install MSRV toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ steps.msrv.outputs.version }}
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: msrv
-    - name: Check workspace builds on MSRV
-      run: cargo check --workspace --all-features --locked
+    - name: Test workspace on MSRV
+      run: cargo test --workspace --all-features --locked
 
   audit:
     name: cargo audit

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@ This guide covers building the enhanced Rust EtherNet/IP library with comprehens
 ## 📋 **Prerequisites**
 
 ### Rust Development Environment
-- **Rust 1.96+** (current stable baseline)
+- **Rust 1.88+**
 - **Cargo** (included with Rust)
 - **Git** for version control
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lowered the workspace MSRV from Rust 1.96 to Rust 1.88, the oldest compiler
+  supported by the locked dependency set and the complete Rust test suite.
+
 ## [1.2.0] - 2026-07-08
 
 Minor release: behavioral fixes, deprecations, and additive surface (C/C++ header

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ Other surface-specific decisions live alongside it under [`docs/agents/notes/`](
 
 ## Workspace Layout
 
-The root `Cargo.toml` defines a workspace containing `.` (main crate) and `examples/desktop_app`. The crate produces both `rlib` and `cdylib` outputs. Rust MSRV is 1.96.
+The root `Cargo.toml` defines a workspace containing `.` (main crate), four sibling crates under `crates/`, and `examples/desktop_app`. The crate produces both `rlib` and `cdylib` outputs. Rust MSRV is 1.88 and is inherited from `[workspace.package].rust-version`.
 
 ## CI
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ members = [
     "examples/desktop_app"  # Desktop application
 ]
 
+[workspace.package]
+rust-version = "1.88"
+
 [package]
 name = "rust-ethernet-ip"
 version = "1.2.0"
@@ -20,7 +23,7 @@ documentation = "https://docs.rs/rust_ethernet_ip"
 readme = "README.md"
 keywords = ["ethernet-ip", "plc", "industrial", "automation", "allen-bradley"]
 categories = ["network-programming", "embedded", "api-bindings"]
-rust-version = "1.96"
+rust-version.workspace = true
 
 # Publish only the Rust crate payload needed by consumers.
 # Patterns are gitignore-style: anchor with a leading `/` so root-level names

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 [![Crates.io](https://img.shields.io/crates/v/rust-ethernet-ip.svg)](https://crates.io/crates/rust-ethernet-ip)
-[![Rust](https://img.shields.io/badge/rust-1.96+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Documentation](https://docs.rs/rust-ethernet-ip/badge.svg)](https://docs.rs/rust-ethernet-ip)
 

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/sergiogallegos/rust-ethernet-ip"
 documentation = "https://docs.rs/rust-ethernet-ip-protocol"
 keywords = ["ethernet-ip", "cip", "plc", "allen-bradley", "industrial"]
 categories = ["network-programming", "encoding"]
-rust-version = "1.96"
+rust-version.workspace = true
 
 [lib]
 name = "rust_ethernet_ip_protocol"

--- a/crates/tag-path/Cargo.toml
+++ b/crates/tag-path/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/sergiogallegos/rust-ethernet-ip"
 documentation = "https://docs.rs/rust-ethernet-ip-tag-path"
 keywords = ["ethernet-ip", "plc", "allen-bradley", "logix", "parser"]
 categories = ["parser-implementations", "network-programming"]
-rust-version = "1.96"
+rust-version.workspace = true
 
 [lib]
 name = "rust_ethernet_ip_tag_path"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/sergiogallegos/rust-ethernet-ip"
 documentation = "https://docs.rs/rust-ethernet-ip-types"
 keywords = ["ethernet-ip", "plc", "allen-bradley", "industrial", "automation"]
 categories = ["data-structures", "network-programming"]
-rust-version = "1.96"
+rust-version.workspace = true
 
 [lib]
 name = "rust_ethernet_ip_types"

--- a/crates/udt/Cargo.toml
+++ b/crates/udt/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/sergiogallegos/rust-ethernet-ip"
 documentation = "https://docs.rs/rust-ethernet-ip-udt"
 keywords = ["ethernet-ip", "plc", "allen-bradley", "logix", "udt"]
 categories = ["data-structures", "network-programming"]
-rust-version = "1.96"
+rust-version.workspace = true
 
 [lib]
 name = "rust_ethernet_ip_udt"

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -18,10 +18,11 @@ The crate follows [Semantic Versioning](https://semver.org/). Within the
 
 ## MSRV policy
 
-- The current MSRV is **Rust 1.96**.
+- The current MSRV is **Rust 1.88**.
 - An MSRV bump is treated as a **minor-version** change, not a patch. Patch
   releases never raise the required compiler.
-- The MSRV is declared via `rust-version` in `Cargo.toml` and exercised by the
+- The MSRV is declared once via `[workspace.package].rust-version` in the root
+  `Cargo.toml`, inherited by every workspace member, and exercised by the
   dedicated CI MSRV job.
 
 ## Enum exhaustiveness

--- a/docs/CODEX_PYTHON_PLATFORM_EXPANSION_PROMPT.md
+++ b/docs/CODEX_PYTHON_PLATFORM_EXPANSION_PROMPT.md
@@ -10,7 +10,7 @@ You are working inside the repository `rust-ethernet-ip`.
   - a C# wrapper
   - tests, examples, docs, build scripts, and release notes
 - The current working line in this repo is `1.0.0`, not `0.8.0`.
-- The Rust baseline is already on Rust 2024 and `rust-version = "1.96"`.
+- The Rust baseline is on Rust 2024 with workspace MSRV `rust-version = "1.88"`.
 - The C# wrapper targets `.NET 10` and `C# 14`.
 
 ## Strategic Goal

--- a/examples/desktop_app/Cargo.toml
+++ b/examples/desktop_app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "desktop_app"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 rust-ethernet-ip = { path = "../.." }

--- a/examples/desktop_app/README.md
+++ b/examples/desktop_app/README.md
@@ -49,7 +49,7 @@ cargo run --release
 
 ## Requirements
 
-- Rust 1.95+
+- Rust 1.88+
 - Tokio runtime
 - egui/eframe for GUI
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,7 +153,6 @@ impl From<rust_ethernet_ip_udt::UdtError> for EtherNetIpError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::assert_matches;
     use std::sync::Mutex;
 
     fn convert_poison_error() -> Result<()> {
@@ -173,7 +172,10 @@ mod tests {
     #[test]
     fn poison_error_converts_to_other_variant() {
         let err = convert_poison_error().expect_err("poisoned mutex should convert into an error");
-        assert_matches!(err, EtherNetIpError::Other(message) if message == "lock poisoned");
+        assert!(matches!(
+            err,
+            EtherNetIpError::Other(message) if message == "lock poisoned"
+        ));
     }
 
     #[test]

--- a/tests/array_read_write_tests.rs
+++ b/tests/array_read_write_tests.rs
@@ -14,7 +14,6 @@
 #[cfg(test)]
 mod tests {
     use rust_ethernet_ip::{EipClient, PlcValue};
-    use std::assert_matches;
     use std::env;
     use tokio::time::{Duration, timeout};
     // Helper function to get test PLC address from environment or use default
@@ -46,7 +45,7 @@ mod tests {
             match client.read_tag(&tag_name).await {
                 Ok(value) => {
                     tracing::info!("Read {}: {:?}", tag_name, value);
-                    assert_matches!(value, PlcValue::Dint(_));
+                    assert!(matches!(value, PlcValue::Dint(_)));
                 }
                 Err(e) => {
                     tracing::error!("Failed to read {}: {}", tag_name, e);
@@ -80,7 +79,7 @@ mod tests {
             match client.read_tag(&tag_name).await {
                 Ok(value) => {
                     tracing::info!("Read {}: {:?}", tag_name, value);
-                    assert_matches!(value, PlcValue::Dint(_));
+                    assert!(matches!(value, PlcValue::Dint(_)));
                 }
                 Err(e) => {
                     tracing::error!("Failed to read {}: {}", tag_name, e);
@@ -163,7 +162,7 @@ mod tests {
             match client.read_tag(&tag_name).await {
                 Ok(value) => {
                     tracing::info!("Read {}: {:?}", tag_name, value);
-                    assert_matches!(value, PlcValue::Bool(_));
+                    assert!(matches!(value, PlcValue::Bool(_)));
                 }
                 Err(e) => {
                     tracing::error!("Failed to read {}: {}", tag_name, e);
@@ -258,7 +257,7 @@ mod tests {
                     tag_name,
                     value
                 );
-                assert_matches!(value, PlcValue::Dint(_));
+                assert!(matches!(value, PlcValue::Dint(_)));
             }
             Err(e) => {
                 tracing::error!("Failed to read {}: {}", tag_name, e);
@@ -297,7 +296,7 @@ mod tests {
             match client.read_tag(&tag_name).await {
                 Ok(value) => {
                     tracing::info!("Read {}: {:?}", tag_name, value);
-                    assert_matches!(value, PlcValue::Dint(_));
+                    assert!(matches!(value, PlcValue::Dint(_)));
                 }
                 Err(e) => {
                     tracing::error!("Failed to read {}: {}", tag_name, e);
@@ -398,7 +397,7 @@ mod tests {
                     tag_name,
                     value
                 );
-                assert_matches!(value, PlcValue::Dint(_));
+                assert!(matches!(value, PlcValue::Dint(_)));
             }
             Err(e) => {
                 tracing::error!("Failed to read {}: {}", tag_name, e);

--- a/tests/batch_operations_tests.rs
+++ b/tests/batch_operations_tests.rs
@@ -11,7 +11,6 @@
 #[cfg(test)]
 mod tests {
     use rust_ethernet_ip::{BatchConfig, BatchOperation, EipClient, PlcValue};
-    use std::assert_matches;
     use std::env;
     use tokio::time::{Duration, timeout};
     // Helper function to get test PLC address from environment or use default
@@ -54,7 +53,7 @@ mod tests {
                     match result {
                         Ok(value) => {
                             tracing::info!("{}: {:?}", tag_name, value);
-                            assert_matches!(value, PlcValue::Dint(_));
+                            assert!(matches!(value, PlcValue::Dint(_)));
                         }
                         Err(e) => {
                             tracing::error!("{}: {}", tag_name, e);

--- a/tests/plc_sim_tests.rs
+++ b/tests/plc_sim_tests.rs
@@ -3,7 +3,6 @@ mod plc_sim;
 use plc_sim::{SimBehavior, SimulatedPlc};
 use rust_ethernet_ip::error::EtherNetIpError;
 use rust_ethernet_ip::{BatchError, EipClient, PlcValue};
-use std::assert_matches;
 
 #[tokio::test]
 async fn simulated_plc_read_write_dint() {
@@ -224,11 +223,11 @@ async fn retired_string_apis_return_unsupported_without_network_write() {
         client.write_string_connected("STRING_TAG", "value").await,
         client.write_string_unconnected("STRING_TAG", "value").await,
     ] {
-        assert_matches!(
+        assert!(matches!(
             result,
             Err(EtherNetIpError::Unsupported { reason, .. })
                 if reason.contains("write_tag")
-        );
+        ));
     }
 
     client
@@ -248,20 +247,20 @@ async fn retired_udt_offset_apis_return_unsupported() {
     let read = client
         .read_udt_member_by_offset("UDT_TAG", 0, 4, 0x00C4)
         .await;
-    assert_matches!(
+    assert!(matches!(
         read,
         Err(EtherNetIpError::Unsupported { api, reason })
             if api == "read_udt_member_by_offset" && reason.contains("CIP reply envelope")
-    );
+    ));
 
     let write = client
         .write_udt_member_by_offset("UDT_TAG", 0, 4, 0x00C4, PlcValue::Dint(1))
         .await;
-    assert_matches!(
+    assert!(matches!(
         write,
         Err(EtherNetIpError::Unsupported { api, reason })
             if api == "write_udt_member_by_offset" && reason.contains("envelope bytes")
-    );
+    ));
 }
 
 #[tokio::test]
@@ -434,13 +433,13 @@ async fn simulated_plc_nested_bool_array_element_read_write() {
         assert_eq!(value, PlcValue::Bool(expected), "index {index}");
     }
 
-    assert_matches!(
+    assert!(matches!(
         client
             .read_tag("UDT_ARRAY[3].BOOL_NESTED[0]")
             .await
             .expect("read nested bit 0"),
         PlcValue::Bool(_)
-    );
+    ));
 
     client
         .write_tag("UDT_ARRAY[3].BOOL_NESTED[5]", PlcValue::Bool(true))

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -53,7 +53,7 @@ Status values:
 - [investigations/monitoring-diagnostics-plan-2026-04-19.md](investigations/monitoring-diagnostics-plan-2026-04-19.md) — Current monitoring and diagnostics gaps plus the recommended Rust-first improvement order. `active`
 - [investigations/docker-example-stacks-2026-04-19.md](investigations/docker-example-stacks-2026-04-19.md) — First local Docker packaging layer for the Python API, collector, and optional MQTT example services. `active`
 - [investigations/rockwell-official-docs-2026-04-16.md](investigations/rockwell-official-docs-2026-04-16.md) — 2026-04-16 check of current official Rockwell EtherNet/IP and Logix data-access publications. `active`
-- [investigations/rust-toolchain-baseline-2026-04-19.md](investigations/rust-toolchain-baseline-2026-04-19.md) — Current Rust baseline, Rust 2024 migration outcome, and MSRV posture after the 2026-04-19 refresh. `active`
+- [investigations/rust-toolchain-baseline-2026-04-19.md](investigations/rust-toolchain-baseline-2026-04-19.md) — Rust 2024 history and the exact Rust 1.88 workspace MSRV boundary verified on 2026-07-14. `confirmed`
 - [investigations/software-architecture-map.md](investigations/software-architecture-map.md) — Current architecture ownership map and links to the maintainer-facing architecture document. `active`
 - [investigations/architecture-review-2026-05-18.md](investigations/architecture-review-2026-05-18.md) — Post-books architecture synthesis and reconciled roadmap from Claude and Codex review passes. `active`
 - [investigations/client-actor-service-retry-2026-05-24.md](investigations/client-actor-service-retry-2026-05-24.md) — Current actor-backed client, connection-event, restricted-write helper, and retry-policy synthesis. `active`

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1151,3 +1151,26 @@ Sources used:
 - `python/rust_ethernet_ip/client.py`
 - `docs/STRING_HANDLING.md`
 - `docs/agents/notes/ab-firmware-quirks.md`
+
+## [2026-07-14] reframe | verify and centralize the Rust 1.88 workspace MSRV
+
+- Updated `wiki/investigations/rust-toolchain-baseline-2026-04-19.md` and
+  `wiki/index.md`.
+- Reframed the toolchain baseline from a current-stable policy to the exact
+  oldest compiler supporting the locked dependencies and complete Rust test
+  suite.
+- Recorded the adjacent boundary: Rust `1.87.0` fails because `time 0.3.47` and
+  `time-core 0.1.8` require Rust `1.88.0`; Rust `1.88.0` compiles the workspace
+  tests with all features.
+- Recorded the passing full Rust `1.88.0` suite and stable formatting/Clippy
+  gates.
+
+Sources used:
+
+- `Cargo.toml`
+- `Cargo.lock`
+- `.github/workflows/ci.yml`
+- `README.md`
+- `BUILD.md`
+- `docs/API_STABILITY.md`
+- `examples/desktop_app/README.md`


### PR DESCRIPTION
Closes #26.

Centralizes the workspace MSRV at Rust 1.88, the oldest compiler supported by the locked dependency graph and complete test suite, and has all six workspace packages inherit it.

It replaces Rust 1.96-only test assertions, makes CI read and test the manifest-declared MSRV, and aligns active documentation and the maintainer wiki.

Validation included the exact Rust 1.87 failure / 1.88 success boundary, the full all-features workspace suite on 1.88, and stable formatting and Clippy across all targets and features; no Rust API, C ABI, or dependency versions changed.
