### PR TITLE
fix(client): page program-scoped tag discovery on CIP 0x06 partial transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lowered the workspace MSRV from Rust 1.96 to Rust 1.88, the oldest compiler
   supported by the locked dependency set and the complete Rust test suite.
 
+### Fixed
+
+- Program-scoped tag discovery aborted on CIP 0x06 "partial transfer" instead of
+  paging, so a program whose symbol table spans more than one response yielded no
+  tags at all.
+
 ## [1.2.0] - 2026-07-08
 
 Minor release: behavioral fixes, deprecations, and additive surface (C/C++ header

--- a/src/client.rs
+++ b/src/client.rs
@@ -949,27 +949,56 @@ impl EipClient {
 
     /// Discovers program-scoped tags
     /// This method discovers tags within a specific program scope
+    ///
+    /// The Symbol Object enumeration is PAGED: a program holding more tags than
+    /// fit in one reply answers with general status `0x06` (partial transfer)
+    /// and the caller must resume from the last instance id returned. This loop
+    /// mirrors [`Self::discover_tags_detailed_internal`]; without it a program
+    /// with many tags surfaced only as `CIP Error 0x06: Partial transfer` and
+    /// none of its tags were reachable.
     pub async fn discover_program_tags(
         &mut self,
         program_name: &str,
     ) -> crate::error::Result<Vec<TagAttributes>> {
-        // Build CIP request for program-scoped tag list
-        let request = self.build_program_tag_list_request(program_name)?;
-        let response = self.send_cip_request(&request).await?;
+        let mut start_instance = 0u32;
+        let mut tags = Vec::new();
 
-        // Extract CIP data from response and check for errors
-        let cip_data = self.extract_cip_from_response(&response)?;
+        loop {
+            let request = self.build_program_tag_list_request(program_name, start_instance)?;
+            let response = self.send_cip_request(&request).await?;
+            let cip_data = self.extract_cip_from_response(&response)?;
 
-        // Check for CIP errors before parsing
-        if let Err(e) = self.check_cip_error(&cip_data) {
-            return Err(crate::error::EtherNetIpError::Protocol(format!(
-                "Program tag discovery failed for '{}': {}. Some PLCs may not support tag discovery. Try reading tags directly by name.",
-                program_name, e
-            )));
+            let page = self.parse_tag_list_response_page(&cip_data).map_err(|e| {
+                crate::error::EtherNetIpError::Protocol(format!(
+                    "Program tag discovery failed for '{}': {}. Some PLCs may not support tag discovery. Try reading tags directly by name.",
+                    program_name, e
+                ))
+            })?;
+
+            tags.extend(page.tags);
+
+            if !page.partial_transfer {
+                break;
+            }
+
+            let Some(last_instance_id) = page.last_instance_id else {
+                return Err(crate::error::EtherNetIpError::Protocol(format!(
+                    "Program tag discovery for '{}' returned Partial transfer without a last instance ID",
+                    program_name
+                )));
+            };
+
+            if last_instance_id == u32::MAX || last_instance_id < start_instance {
+                return Err(crate::error::EtherNetIpError::Protocol(format!(
+                    "Program tag discovery for '{}' pagination stalled at instance {}",
+                    program_name, last_instance_id
+                )));
+            }
+
+            start_instance = last_instance_id.saturating_add(1);
         }
 
-        // Parse response
-        self.parse_tag_list_response(&cip_data)
+        Ok(tags)
     }
 
     /// Lists all cached tag attributes
@@ -2753,8 +2782,23 @@ impl EipClient {
         Ok(request)
     }
 
-    /// Builds CIP request for program-scoped tag list discovery.
-    fn build_program_tag_list_request(&self, program_name: &str) -> crate::error::Result<Vec<u8>> {
+    /// Builds CIP request for program-scoped tag list discovery, resuming the
+    /// Symbol Object enumeration at `start_instance`.
+    ///
+    /// A program with more tags than fit in one reply answers `0x06`
+    /// (partial transfer); the caller resumes from `last_instance_id + 1`, the
+    /// same paging contract as [`Self::build_tag_list_request_from_instance`].
+    fn build_program_tag_list_request(
+        &self,
+        program_name: &str,
+        start_instance: u32,
+    ) -> crate::error::Result<Vec<u8>> {
+        let start_instance = u16::try_from(start_instance).map_err(|_| {
+            crate::error::EtherNetIpError::Protocol(format!(
+                "Program tag discovery start instance {} exceeds 16-bit Symbol Object range",
+                start_instance
+            ))
+        })?;
         let scoped_program = if program_name.starts_with("Program:") {
             program_name.to_string()
         } else {
@@ -2768,10 +2812,9 @@ impl EipClient {
         if !path.len().is_multiple_of(2) {
             path.push(0x00);
         }
-        path.extend_from_slice(&[
-            // Symbol Object (Class 0x6B), start instance 0.
-            0x20, 0x6B, 0x25, 0x00, 0x00, 0x00,
-        ]);
+        // Symbol Object (Class 0x6B), 16-bit start instance.
+        path.extend_from_slice(&[0x20, 0x6B, 0x25, 0x00]);
+        path.extend_from_slice(&start_instance.to_le_bytes());
 
         let path_words = u8::try_from(path.len() / 2).map_err(|_| {
             crate::error::EtherNetIpError::Protocol(format!(
@@ -2916,11 +2959,6 @@ impl EipClient {
             last_instance_id,
             partial_transfer,
         })
-    }
-
-    /// Parses tag list response from CIP
-    fn parse_tag_list_response(&self, response: &[u8]) -> crate::error::Result<Vec<TagAttributes>> {
-        Ok(self.parse_tag_list_response_page(response)?.tags)
     }
 
     /// Negotiates packet size with the PLC
@@ -4333,7 +4371,7 @@ mod discovery_tests {
     fn build_program_tag_list_request_includes_program_symbol_scope() {
         let client = EipClient::new_unconnected_for_testing();
         let request = client
-            .build_program_tag_list_request("MainProgram")
+            .build_program_tag_list_request("MainProgram", 0)
             .expect("request should build");
 
         let mut expected = vec![0x55, 0x0E, 0x91, 0x13];
@@ -4347,6 +4385,41 @@ mod discovery_tests {
         ]);
 
         assert_eq!(request, expected);
+    }
+
+    #[test]
+    fn build_program_tag_list_request_resumes_at_start_instance() {
+        let client = EipClient::new_unconnected_for_testing();
+        let request = client
+            .build_program_tag_list_request("MainProgram", 0x1235)
+            .expect("request should build");
+
+        // Only the instance segment moves: the program symbolic path, the
+        // service and the requested attributes are identical to instance 0.
+        let mut expected = vec![0x55, 0x0E, 0x91, 0x13];
+        expected.extend_from_slice(b"Program:MainProgram");
+        expected.push(0x00);
+        expected.extend_from_slice(&[
+            0x20, 0x6B, 0x25, 0x00, 0x35, 0x12, // Symbol class, instance 0x1235 LE
+            0x02, 0x00, // attribute count
+            0x01, 0x00, // Symbol Name
+            0x02, 0x00, // Symbol Type
+        ]);
+
+        assert_eq!(request, expected);
+    }
+
+    #[test]
+    fn build_program_tag_list_request_rejects_out_of_range_start_instance() {
+        let client = EipClient::new_unconnected_for_testing();
+        let error = client
+            .build_program_tag_list_request("MainProgram", u32::from(u16::MAX) + 1)
+            .expect_err("start instance beyond the 16-bit range must be refused");
+
+        assert!(
+            error.to_string().contains("16-bit Symbol Object range"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`discover_program_tags()` returns `CIP Error 0x06: Partial transfer` and **zero
tags** for any program holding more tags than fit in a single reply.

The Symbol Object enumeration is paged: a controller answers general status
`0x06` to mean "here is a page, ask again from the last instance id". The
controller-scoped path (`discover_tags_detailed`) already handles this -- it
loops on `0x06` and resumes from `last_instance_id + 1`. The program-scoped path
did not: it issued a single request with the start instance hardcoded to 0 and
treated `0x06` as fatal.

The result is that program tags are unreachable on any realistically sized
program, and the failure surfaces as a protocol error rather than as truncation.

## Fix

Parameterise the start instance in `build_program_tag_list_request()` and run
the same paging loop the controller-scoped twin already uses, reusing the
existing `parse_tag_list_response_page()` (already written and already tested
upstream). No new parsing logic.

Guard rails kept explicit rather than silent:

- pagination that stalls (`last_instance_id` not advancing, or `u32::MAX`) is a
  typed error, not an infinite loop;
- a start instance beyond the 16-bit Symbol Object range is refused up front.

## Note on the removed private method

This diff also **removes the private `parse_tag_list_response()`**. It became
dead code: `discover_program_tags()` was its only caller, and it now calls
`parse_tag_list_response_page()` directly to drive the loop. Flagging it so the
removal of a private method inside a pagination fix does not look out of place.

## Tests

Three unit tests added:

- the request builder encodes start instance 0 (unchanged behaviour);
- it resumes at a non-zero instance (`0x1235`), which is the paging contract;
- it refuses a start instance outside the 16-bit Symbol Object range.

## Test evidence

```
cargo fmt --check                                      # clean
cargo clippy -p rust-ethernet-ip --lib -- -D warnings  # clean
cargo test --workspace --all-targets                   # 1 pre-existing failure
```

The failure is `plc_manager::tests::test_plc_manager_connection_pool`, which is
**pre-existing and unrelated** -- it fails identically on unmodified `main`
(verified by re-running it without the fix), as it requires a reachable PLC.

The C# test suite (`dotnet test csharp/RustEtherNetIp.Tests`) was **not run
locally** -- no .NET SDK on the machine this was developed on. The change is
confined to two private Rust methods and does not touch the FFI boundary, so I
am relying on upstream CI for that suite; happy to install the SDK and report
locally if you would rather have it before merging.

## Hardware validation

Validated on a **CompactLogix 5380**, program `Dashboard`, same command against
both binaries:

| Binary | Result |
|---|---|
| `rust-ethernet-ip` 1.2.0 as published | `CIP Error 0x06: Partial transfer` -- 0 tags |
| with this fix | **20 tags** (10 controller-scoped + 10 program-scoped) |

## Known limitation, deliberately not addressed here

The start instance is bounded to 16 bits (`0x25 0x00` + u16), mirroring the
controller-scoped twin. Past `0xFFFF` the fix returns an error *after* pages have
already been collected, and those pages are lost. Moving to the 32-bit segment
(`0x26 0x00` + u32) would fix both functions but widens the PR -- I kept it
minimal and consistent with the existing code. Happy to do it here or in a
follow-up, your call.

## Relationship to my other PR

I have a second, separate PR fixing `TagScope` propagation for program-scoped
discovery (tags found by this fix are currently all reported as
`TagScope::Controller`).

The two **touch the same file and will conflict textually** depending on merge
order: that PR adds a parameter to `parse_tag_list_response()`, which this one
deletes. The resolution is mechanical -- if this PR merges first, the other
simply drops that hunk. **I will rebase whichever lands second**; no review
effort needed on your side.